### PR TITLE
Add outputs for all current CN, CAN packages

### DIFF
--- a/mappings/package_can_v1.10/output/sdk_examples_can-1.10/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can-1.10/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/comp-tend>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_23/veat_23.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_23/veat_23.ttl
@@ -1,0 +1,279 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AwardDecision_RCZ4KemxRj7U6WkmaKdG6M a
+    epo:AwardDecision;
+  epo:hasAwardDecisionDate "2022-10-25+02:00"^^xsd:date .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Projektmanager NKHR, Controlling";
+  epo:hasFax "+49 6223804-9799";
+  epo:hasInternetAddress "https://www.neckargemuend.de"^^xsd:anyURI;
+  cccev:email "nkhr@neckargemuend.de";
+  cccev:telephone "+49 6223804-701" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+49 62239252-25";
+  cccev:email "info@stadtwerke-neckargemuend.de";
+  cccev:telephone "+49 62239252-0" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:address epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Die Stadtwerke Neckargemünd GmbH (SWN) verfügt über zum Teil alleinige Wasserbezugsrechte, die für die Bereitstellung des Trinkwassers zur Versorgung der Stadt Neckargemünd erforderlich sind und über die kein potentieller Wettbewerber verfügt. Denn diese Wasserbezugsrechte sind satzungsrechtlich mit der Mitgliedschaft der SWN in den Zweckverbänden Bodensee-Wasserversorgung und Unteres Elsenztal verknüpft. Mitglied der Zweckverbände ist allein die SWN, nicht die Stadt Neckargemünd, so dass auch keine (auf die Dauer des Konzessionsvertrags befristete) Übertragung dieser Rechte von der Stadt auf das Wasserversorgungsunternehmen möglich ist. Die Rechte stehen allein der SWN kraft ihrer eigenen Mitgliedschaft zu."@de;
+  epo:refersToPreviousProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/65110000> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Konzessionsvertrag: Der Wasser-Konzessionsvertrag enthält neben den Regelungen zur Wegenutzung auch eine Lieferverpflichtung zur Trinkwasserversorgung. Ziel des Vertrages ist es, durch Planung, Bau, Betrieb und Instandhaltung von Wasserversorgungsanlagen unter Nutzung der öffentlichen Verkehrswege der Stadt eine möglichst sichere, preisgünstige, umweltverträgliche und verbraucherfreundliche Versorgung der Einwohner und Gewerbetreibenden im Stadtgebiet von Neckargemünd mit Wasser in guter Qualität zu
+			gewährleisten. Als Entgelt für die eingeräumten Nutzungsrechte sind Konzessionsabgaben im jeweils höchstzulässigen Umfang vereinbart.
+			Der Konzessionsvertrag wird rückwirkend zum 01.01.2022 beginnen und nach 20 Jahren mit Ablauf des 31.12.2041 zunächst enden. Sofern die Stadt nicht kündigt, verlängert sich der Vertrag automatisch um zweimal 10 Jahre. Die Laufzeit beträgt somit bis zu 40 Jahre. Eine gesetzliche festgelegte Maximallaufzeit existiert nicht.
+			Löschwasservereinbarung: Die Stadt Neckargemünd hat gemäß § 3 Absatz 1 Satz 2 Nr. 3 Feuerwehrgesetz Baden-Württemberg (FwG) für die ständige Bereithaltung von Löschwasservorräten zu sorgen. Die der Stadt zur Verfügung stehenden Löschwasserbereitstellungskapazitäten außerhalb der öffentlichen Trinkwasserversorgung reichen nicht aus. Die Stadt ist daher auf die Möglichkeit zur Entnahme von Trinkwasser angewiesen. Der Wasser-Konzessionsvertrag verweist auf die gesonderte Löschwasservereinbarung. In ihr
+			wird geregelt, inwiefern die Stadtwerke Neckargemünd GmbH über das Trinkwassernetz zur Vorhaltung ausreichender Löschwasservorräte im Stadtgebiet beitragen kann und soll.
+			Da die Löschwasservereinbarung an den Wasser-Konzessionsvertrag gekoppelt ist, beginnt und endet sie entsprechend."""@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 10000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Notice a epo:Notice, epo:Notice28, epo:ResultNotice;
+  epo:announcesNoticeAwardInformation epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-01-10T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/DEU>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "9938e0b2-bba7-4123-b96b-a654440660bf" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Stadt Neckargemünd"@de;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Stadtwerke Neckargemünd GmbH"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/DEU>;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "f83d19fa-192f-4eba-acc0-b1a6ac8862c7" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0023>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt;
+  dct:description "Abschluss eines Wasser-Konzessionsvertrags sowie einer Löschwasservereinbarung"@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002;
+  dct:description "ted-esen" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD a epo:Reviewer;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContract_CON-0001 a epo:Contract;
+  epo:includesTender epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2023-02" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 .

--- a/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_24/veat_24.ttl
@@ -1,0 +1,450 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_25/veat_25.ttl
@@ -1,0 +1,367 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "222 333 444" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_81/veat_81.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can-1.10/veat_81/veat_81.ttl
@@ -1,0 +1,294 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesOfflineAccessProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS;
+  epo:definesProcurementProcedureInformationProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Buyer_PbuuQVDAP9jvgtF6eprdW2 a epo:Buyer;
+  epo:hasBuyerProfile "https://example.com"^^xsd:anyURI;
+  epo:isContractingEntity true;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/EL303>;
+  locn:fullAddress "Future Solutions Division, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, New Horizons, CA, 117 43, GRC";
+  locn:postCode "117 43";
+  locn:postName "New Horizons, CA" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/EL303>;
+  locn:postCode "117 43";
+  locn:postName "Patra " .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Info";
+  epo:hasFax "+1 (555) 123-4567";
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com"^^xsd:anyURI;
+  cccev:email "info@zenithnovainnovations.com";
+  cccev:telephone "+1 (555) 123-4567" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  cccev:email "patra@pat.gr";
+  cccev:telephone "1444452222" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON>;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere in the given country"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP
+  a epo:GreenProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/environmental-impact/circ-econ> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 a adms:Identifier;
+  skos:notation "ORG-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 a adms:Identifier;
+  skos:notation "ORG-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw
+  a epo:InnovativeProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/innovative-acquisition/prod-innov> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63
+  a adms:Identifier;
+  skos:notation "ABF" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  dct:description """Sinopsis vol2 LOT1 
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT1 """@en;
+  dct:title "Ante nte vol2 LOT1 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:fulfillsStrategicProcurement epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt;
+  dct:description """Sinopsis vol2 LOT2
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT2"""@en;
+  dct:title "Ante nte vol2 LOT2"@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Notice a epo:Notice, epo:Notice27, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-05-26T11:16:47Z"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:refersToProcedure epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:OfflineAccessProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/spec-rights-entity>;
+  epo:hasLegalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "ZenithNova Innovations Ltd."@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/electricity>;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 a epo:Business,
+    org:Organization;
+  epo:hasLegalName "New Org "@en;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  epo:isListedCompany true;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "75db4bef-aae6-41f1-a593-d5dc62abd907" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32009L0081>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:description """The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 """@en;
+  dct:title "Ante nte vol2 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS a epo:Reviewer;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "d1cc5b48-fefc-405f-b888-b0727cd632a0-01" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:includesTender epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tender_TEN-0001;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/opp> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/hum-right> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID 123" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tender_TEN-0001 a epo:Tender;
+  epo:isSubmitedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  locn:fullAddress "Future Solutions Division" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com/contact-us/katerina-lisa"^^xsd:anyURI;
+  dct:description "Katerina Lisa"@en;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.10/output/sdk_examples_can_invalid-1.10/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
+++ b/mappings/package_can_v1.10/output/sdk_examples_can_invalid-1.10/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
@@ -55,6 +55,9 @@ epd:id__LotIdentifier_jucn4erQJnXcty2wPoNNzB a adms:Identifier;
   epo:hasScheme "Lot";
   skos:notation "" .
 
+epd:id__LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6 a adms:Identifier;
+  skos:notation "" .
+
 epd:id__LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose .
 
 epd:id__Lot_LOT-0000 a epo:Lot .

--- a/mappings/package_can_v1.3/output/sdk_examples_can-1.3/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.3/output/sdk_examples_can-1.3/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.3/output/sdk_examples_can-1.3/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.3/output/sdk_examples_can-1.3/veat_24/veat_24.ttl
@@ -1,0 +1,445 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.3/output/sdk_examples_can-1.3/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.3/output/sdk_examples_can-1.3/veat_25/veat_25.ttl
@@ -1,0 +1,362 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.4/output/sdk_examples_can-1.4/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.4/output/sdk_examples_can-1.4/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.4/output/sdk_examples_can-1.4/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.4/output/sdk_examples_can-1.4/veat_24/veat_24.ttl
@@ -1,0 +1,445 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.4/output/sdk_examples_can-1.4/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.4/output/sdk_examples_can-1.4/veat_25/veat_25.ttl
@@ -1,0 +1,362 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.5/output/sdk_examples_can-1.5/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.5/output/sdk_examples_can-1.5/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.5/output/sdk_examples_can-1.5/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.5/output/sdk_examples_can-1.5/veat_24/veat_24.ttl
@@ -1,0 +1,445 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.5/output/sdk_examples_can-1.5/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.5/output/sdk_examples_can-1.5/veat_25/veat_25.ttl
@@ -1,0 +1,362 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.6/output/sdk_examples_can-1.6/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.6/output/sdk_examples_can-1.6/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_23/veat_23.ttl
+++ b/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_23/veat_23.ttl
@@ -1,0 +1,251 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AwardDecision_RCZ4KemxRj7U6WkmaKdG6M a
+    epo:AwardDecision;
+  epo:hasAwardDecisionDate "2022-10-25+02:00"^^xsd:date .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Projektmanager NKHR, Controlling";
+  epo:hasFax "+49 6223804-9799";
+  epo:hasInternetAddress "https://www.neckargemuend.de"^^xsd:anyURI;
+  cccev:email "nkhr@neckargemuend.de";
+  cccev:telephone "+49 6223804-701" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+49 62239252-25";
+  cccev:email "info@stadtwerke-neckargemuend.de";
+  cccev:telephone "+49 62239252-0" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Die Stadtwerke Neckargemünd GmbH (SWN) verfügt über zum Teil alleinige Wasserbezugsrechte, die für die Bereitstellung des Trinkwassers zur Versorgung der Stadt Neckargemünd erforderlich sind und über die kein potentieller Wettbewerber verfügt. Denn diese Wasserbezugsrechte sind satzungsrechtlich mit der Mitgliedschaft der SWN in den Zweckverbänden Bodensee-Wasserversorgung und Unteres Elsenztal verknüpft. Mitglied der Zweckverbände ist allein die SWN, nicht die Stadt Neckargemünd, so dass auch keine (auf die Dauer des Konzessionsvertrags befristete) Übertragung dieser Rechte von der Stadt auf das Wasserversorgungsunternehmen möglich ist. Die Rechte stehen allein der SWN kraft ihrer eigenen Mitgliedschaft zu."@de;
+  epo:refersToPreviousProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/65110000> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Konzessionsvertrag: Der Wasser-Konzessionsvertrag enthält neben den Regelungen zur Wegenutzung auch eine Lieferverpflichtung zur Trinkwasserversorgung. Ziel des Vertrages ist es, durch Planung, Bau, Betrieb und Instandhaltung von Wasserversorgungsanlagen unter Nutzung der öffentlichen Verkehrswege der Stadt eine möglichst sichere, preisgünstige, umweltverträgliche und verbraucherfreundliche Versorgung der Einwohner und Gewerbetreibenden im Stadtgebiet von Neckargemünd mit Wasser in guter Qualität zu
+			gewährleisten. Als Entgelt für die eingeräumten Nutzungsrechte sind Konzessionsabgaben im jeweils höchstzulässigen Umfang vereinbart.
+			Der Konzessionsvertrag wird rückwirkend zum 01.01.2022 beginnen und nach 20 Jahren mit Ablauf des 31.12.2041 zunächst enden. Sofern die Stadt nicht kündigt, verlängert sich der Vertrag automatisch um zweimal 10 Jahre. Die Laufzeit beträgt somit bis zu 40 Jahre. Eine gesetzliche festgelegte Maximallaufzeit existiert nicht.
+			Löschwasservereinbarung: Die Stadt Neckargemünd hat gemäß § 3 Absatz 1 Satz 2 Nr. 3 Feuerwehrgesetz Baden-Württemberg (FwG) für die ständige Bereithaltung von Löschwasservorräten zu sorgen. Die der Stadt zur Verfügung stehenden Löschwasserbereitstellungskapazitäten außerhalb der öffentlichen Trinkwasserversorgung reichen nicht aus. Die Stadt ist daher auf die Möglichkeit zur Entnahme von Trinkwasser angewiesen. Der Wasser-Konzessionsvertrag verweist auf die gesonderte Löschwasservereinbarung. In ihr
+			wird geregelt, inwiefern die Stadtwerke Neckargemünd GmbH über das Trinkwassernetz zur Vorhaltung ausreichender Löschwasservorräte im Stadtgebiet beitragen kann und soll.
+			Da die Löschwasservereinbarung an den Wasser-Konzessionsvertrag gekoppelt ist, beginnt und endet sie entsprechend."""@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 10000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Notice a epo:Notice, epo:Notice28, epo:ResultNotice;
+  epo:announcesNoticeAwardInformation epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-01-10T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/DEU>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "9938e0b2-bba7-4123-b96b-a654440660bf" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Stadt Neckargemünd"@de;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Stadtwerke Neckargemünd GmbH"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "f83d19fa-192f-4eba-acc0-b1a6ac8862c7" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0023>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt;
+  dct:description "Abschluss eines Wasser-Konzessionsvertrags sowie einer Löschwasservereinbarung"@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002;
+  dct:description "ted-esen" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD a epo:Reviewer;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContract_CON-0001 a epo:Contract;
+  epo:includesTender epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2023-02" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 .

--- a/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_24/veat_24.ttl
@@ -1,0 +1,445 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.6/output/sdk_examples_can-1.6/veat_25/veat_25.ttl
@@ -1,0 +1,362 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.7/output/sdk_examples_can-1.7/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.7/output/sdk_examples_can-1.7/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_23/veat_23.ttl
+++ b/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_23/veat_23.ttl
@@ -1,0 +1,256 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AwardDecision_RCZ4KemxRj7U6WkmaKdG6M a
+    epo:AwardDecision;
+  epo:hasAwardDecisionDate "2022-10-25+02:00"^^xsd:date .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Projektmanager NKHR, Controlling";
+  epo:hasFax "+49 6223804-9799";
+  epo:hasInternetAddress "https://www.neckargemuend.de"^^xsd:anyURI;
+  cccev:email "nkhr@neckargemuend.de";
+  cccev:telephone "+49 6223804-701" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+49 62239252-25";
+  cccev:email "info@stadtwerke-neckargemuend.de";
+  cccev:telephone "+49 62239252-0" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Die Stadtwerke Neckargemünd GmbH (SWN) verfügt über zum Teil alleinige Wasserbezugsrechte, die für die Bereitstellung des Trinkwassers zur Versorgung der Stadt Neckargemünd erforderlich sind und über die kein potentieller Wettbewerber verfügt. Denn diese Wasserbezugsrechte sind satzungsrechtlich mit der Mitgliedschaft der SWN in den Zweckverbänden Bodensee-Wasserversorgung und Unteres Elsenztal verknüpft. Mitglied der Zweckverbände ist allein die SWN, nicht die Stadt Neckargemünd, so dass auch keine (auf die Dauer des Konzessionsvertrags befristete) Übertragung dieser Rechte von der Stadt auf das Wasserversorgungsunternehmen möglich ist. Die Rechte stehen allein der SWN kraft ihrer eigenen Mitgliedschaft zu."@de;
+  epo:refersToPreviousProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/65110000> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Konzessionsvertrag: Der Wasser-Konzessionsvertrag enthält neben den Regelungen zur Wegenutzung auch eine Lieferverpflichtung zur Trinkwasserversorgung. Ziel des Vertrages ist es, durch Planung, Bau, Betrieb und Instandhaltung von Wasserversorgungsanlagen unter Nutzung der öffentlichen Verkehrswege der Stadt eine möglichst sichere, preisgünstige, umweltverträgliche und verbraucherfreundliche Versorgung der Einwohner und Gewerbetreibenden im Stadtgebiet von Neckargemünd mit Wasser in guter Qualität zu
+			gewährleisten. Als Entgelt für die eingeräumten Nutzungsrechte sind Konzessionsabgaben im jeweils höchstzulässigen Umfang vereinbart.
+			Der Konzessionsvertrag wird rückwirkend zum 01.01.2022 beginnen und nach 20 Jahren mit Ablauf des 31.12.2041 zunächst enden. Sofern die Stadt nicht kündigt, verlängert sich der Vertrag automatisch um zweimal 10 Jahre. Die Laufzeit beträgt somit bis zu 40 Jahre. Eine gesetzliche festgelegte Maximallaufzeit existiert nicht.
+			Löschwasservereinbarung: Die Stadt Neckargemünd hat gemäß § 3 Absatz 1 Satz 2 Nr. 3 Feuerwehrgesetz Baden-Württemberg (FwG) für die ständige Bereithaltung von Löschwasservorräten zu sorgen. Die der Stadt zur Verfügung stehenden Löschwasserbereitstellungskapazitäten außerhalb der öffentlichen Trinkwasserversorgung reichen nicht aus. Die Stadt ist daher auf die Möglichkeit zur Entnahme von Trinkwasser angewiesen. Der Wasser-Konzessionsvertrag verweist auf die gesonderte Löschwasservereinbarung. In ihr
+			wird geregelt, inwiefern die Stadtwerke Neckargemünd GmbH über das Trinkwassernetz zur Vorhaltung ausreichender Löschwasservorräte im Stadtgebiet beitragen kann und soll.
+			Da die Löschwasservereinbarung an den Wasser-Konzessionsvertrag gekoppelt ist, beginnt und endet sie entsprechend."""@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 10000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Notice a epo:Notice, epo:Notice28, epo:ResultNotice;
+  epo:announcesNoticeAwardInformation epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-01-10T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/DEU>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "9938e0b2-bba7-4123-b96b-a654440660bf" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Stadt Neckargemünd"@de;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Stadtwerke Neckargemünd GmbH"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "f83d19fa-192f-4eba-acc0-b1a6ac8862c7" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0023>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt;
+  dct:description "Abschluss eines Wasser-Konzessionsvertrags sowie einer Löschwasservereinbarung"@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002;
+  dct:description "ted-esen" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD a epo:Reviewer;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContract_CON-0001 a epo:Contract;
+  epo:includesTender epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2023-02" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 .

--- a/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_24/veat_24.ttl
@@ -1,0 +1,450 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.7/output/sdk_examples_can-1.7/veat_25/veat_25.ttl
@@ -1,0 +1,367 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.7/output/sdk_examples_can_invalid-1.7/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
+++ b/mappings/package_can_v1.7/output/sdk_examples_can_invalid-1.7/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
@@ -55,6 +55,9 @@ epd:id__LotIdentifier_jucn4erQJnXcty2wPoNNzB a adms:Identifier;
   epo:hasScheme "Lot";
   skos:notation "" .
 
+epd:id__LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6 a adms:Identifier;
+  skos:notation "" .
+
 epd:id__LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose .
 
 epd:id__Lot_LOT-0000 a epo:Lot .

--- a/mappings/package_can_v1.8/output/sdk_examples_can-1.8/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can-1.8/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_23/veat_23.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_23/veat_23.ttl
@@ -1,0 +1,279 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AwardDecision_RCZ4KemxRj7U6WkmaKdG6M a
+    epo:AwardDecision;
+  epo:hasAwardDecisionDate "2022-10-25+02:00"^^xsd:date .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Projektmanager NKHR, Controlling";
+  epo:hasFax "+49 6223804-9799";
+  epo:hasInternetAddress "https://www.neckargemuend.de"^^xsd:anyURI;
+  cccev:email "nkhr@neckargemuend.de";
+  cccev:telephone "+49 6223804-701" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+49 62239252-25";
+  cccev:email "info@stadtwerke-neckargemuend.de";
+  cccev:telephone "+49 62239252-0" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:address epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Die Stadtwerke Neckargemünd GmbH (SWN) verfügt über zum Teil alleinige Wasserbezugsrechte, die für die Bereitstellung des Trinkwassers zur Versorgung der Stadt Neckargemünd erforderlich sind und über die kein potentieller Wettbewerber verfügt. Denn diese Wasserbezugsrechte sind satzungsrechtlich mit der Mitgliedschaft der SWN in den Zweckverbänden Bodensee-Wasserversorgung und Unteres Elsenztal verknüpft. Mitglied der Zweckverbände ist allein die SWN, nicht die Stadt Neckargemünd, so dass auch keine (auf die Dauer des Konzessionsvertrags befristete) Übertragung dieser Rechte von der Stadt auf das Wasserversorgungsunternehmen möglich ist. Die Rechte stehen allein der SWN kraft ihrer eigenen Mitgliedschaft zu."@de;
+  epo:refersToPreviousProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/65110000> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Konzessionsvertrag: Der Wasser-Konzessionsvertrag enthält neben den Regelungen zur Wegenutzung auch eine Lieferverpflichtung zur Trinkwasserversorgung. Ziel des Vertrages ist es, durch Planung, Bau, Betrieb und Instandhaltung von Wasserversorgungsanlagen unter Nutzung der öffentlichen Verkehrswege der Stadt eine möglichst sichere, preisgünstige, umweltverträgliche und verbraucherfreundliche Versorgung der Einwohner und Gewerbetreibenden im Stadtgebiet von Neckargemünd mit Wasser in guter Qualität zu
+			gewährleisten. Als Entgelt für die eingeräumten Nutzungsrechte sind Konzessionsabgaben im jeweils höchstzulässigen Umfang vereinbart.
+			Der Konzessionsvertrag wird rückwirkend zum 01.01.2022 beginnen und nach 20 Jahren mit Ablauf des 31.12.2041 zunächst enden. Sofern die Stadt nicht kündigt, verlängert sich der Vertrag automatisch um zweimal 10 Jahre. Die Laufzeit beträgt somit bis zu 40 Jahre. Eine gesetzliche festgelegte Maximallaufzeit existiert nicht.
+			Löschwasservereinbarung: Die Stadt Neckargemünd hat gemäß § 3 Absatz 1 Satz 2 Nr. 3 Feuerwehrgesetz Baden-Württemberg (FwG) für die ständige Bereithaltung von Löschwasservorräten zu sorgen. Die der Stadt zur Verfügung stehenden Löschwasserbereitstellungskapazitäten außerhalb der öffentlichen Trinkwasserversorgung reichen nicht aus. Die Stadt ist daher auf die Möglichkeit zur Entnahme von Trinkwasser angewiesen. Der Wasser-Konzessionsvertrag verweist auf die gesonderte Löschwasservereinbarung. In ihr
+			wird geregelt, inwiefern die Stadtwerke Neckargemünd GmbH über das Trinkwassernetz zur Vorhaltung ausreichender Löschwasservorräte im Stadtgebiet beitragen kann und soll.
+			Da die Löschwasservereinbarung an den Wasser-Konzessionsvertrag gekoppelt ist, beginnt und endet sie entsprechend."""@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 10000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Notice a epo:Notice, epo:Notice28, epo:ResultNotice;
+  epo:announcesNoticeAwardInformation epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-01-10T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/DEU>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "9938e0b2-bba7-4123-b96b-a654440660bf" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Stadt Neckargemünd"@de;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Stadtwerke Neckargemünd GmbH"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/DEU>;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "f83d19fa-192f-4eba-acc0-b1a6ac8862c7" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0023>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt;
+  dct:description "Abschluss eines Wasser-Konzessionsvertrags sowie einer Löschwasservereinbarung"@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002;
+  dct:description "ted-esen" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD a epo:Reviewer;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContract_CON-0001 a epo:Contract;
+  epo:includesTender epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2023-02" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 .

--- a/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_24/veat_24.ttl
@@ -1,0 +1,450 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_25/veat_25.ttl
@@ -1,0 +1,367 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_81/veat_81.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can-1.8/veat_81/veat_81.ttl
@@ -1,0 +1,289 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesOfflineAccessProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS;
+  epo:definesProcurementProcedureInformationProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Buyer_PbuuQVDAP9jvgtF6eprdW2 a epo:Buyer;
+  epo:hasBuyerProfile "https://example.com"^^xsd:anyURI;
+  epo:isContractingEntity true;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/EL303>;
+  locn:fullAddress "Future Solutions Division, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, New Horizons, CA, 117 43, GRC";
+  locn:postCode "117 43";
+  locn:postName "New Horizons, CA" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  locn:postName "Patra " .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Info";
+  epo:hasFax "+1 (555) 123-4567";
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com"^^xsd:anyURI;
+  cccev:email "info@zenithnovainnovations.com";
+  cccev:telephone "+1 (555) 123-4567" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  cccev:email "patra@pat.gr";
+  cccev:telephone "1444452222" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON>;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere in the given country"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP
+  a epo:GreenProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/environmental-impact/circ-econ> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 a adms:Identifier;
+  skos:notation "ORG-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 a adms:Identifier;
+  skos:notation "ORG-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw
+  a epo:InnovativeProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/innovative-acquisition/prod-innov> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  dct:description """Sinopsis vol2 LOT1 
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT1 """@en;
+  dct:title "Ante nte vol2 LOT1 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:fulfillsStrategicProcurement epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt;
+  dct:description """Sinopsis vol2 LOT2
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT2"""@en;
+  dct:title "Ante nte vol2 LOT2"@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Notice a epo:Notice, epo:Notice27, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-05-26T11:16:47Z"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:refersToProcedure epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:OfflineAccessProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/spec-rights-entity>;
+  epo:hasLegalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "ZenithNova Innovations Ltd."@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/electricity>;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalName "New Org "@en;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "75db4bef-aae6-41f1-a593-d5dc62abd907" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32009L0081>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:description """The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 """@en;
+  dct:title "Ante nte vol2 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS a epo:Reviewer;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "d1cc5b48-fefc-405f-b888-b0727cd632a0-01" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/opp> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/hum-right> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID 123" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tender_TEN-0001 a epo:Tender;
+  epo:isSubmitedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  locn:fullAddress "Future Solutions Division" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com/contact-us/katerina-lisa"^^xsd:anyURI;
+  dct:description "Katerina Lisa"@en;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.8/output/sdk_examples_can_invalid-1.8/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
+++ b/mappings/package_can_v1.8/output/sdk_examples_can_invalid-1.8/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
@@ -55,6 +55,9 @@ epd:id__LotIdentifier_jucn4erQJnXcty2wPoNNzB a adms:Identifier;
   epo:hasScheme "Lot";
   skos:notation "" .
 
+epd:id__LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6 a adms:Identifier;
+  skos:notation "" .
+
 epd:id__LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose .
 
 epd:id__Lot_LOT-0000 a epo:Lot .

--- a/mappings/package_can_v1.9/output/sdk_examples_can-1.9/t02_ESP/t02_ESP.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can-1.9/t02_ESP/t02_ESP.ttl
@@ -1,0 +1,286 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:isContractingEntity false;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Paseo Castellana, 67, Madrid, 28071, ESP";
+  locn:postCode "28071";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Avenida Pío XII, 110, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Dirección General de Transporte Terrestre";
+  epo:hasFax "+34 9159770009";
+  epo:hasInternetAddress "https://www.mitma.es/"^^xsd:anyURI;
+  cccev:email "sgatt@fomento.es";
+  cccev:telephone "+34 915977000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "(+234) 987659";
+  epo:hasInternetAddress "https://www.renfe.com/"^^xsd:anyURI;
+  cccev:email "contact@hulk-comp.com";
+  cccev:telephone "(+234) 98765" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D
+  a epo:SpecificDuration;
+  time:numericDuration 120.0;
+  time:unitType time:unitMonth .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  locn:address epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocationAddress_5zVCW3b2MSxAnzMuZRbDZB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D
+  a epo:Period;
+  epo:hasBeginning "2020-09-01+02:00"^^xsd:date .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractDuration_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesContractPeriod epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractPeriod_4TghaR9Riayv2Hb6XHyc6D;
+  epo:definesSpecificPlaceOfPerformance epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_AccessTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Contrato entre la Administración General del Estado y la Sociedad Mercantil Estatal Renfe Viajeros, S. M. E., S. A., para la prestación de los servicios públicos de transporte de viajeros por ferrocarril de Cercanías, Media Distancia Convencional, Alta Velocidad Media Distancia (Avant) y ancho métrico, competencia de la Administración General del Estado, sujetos a obligaciones de servicio público en el periodo 2018-2027.
+(nature and quantity of services or indication of needs and requirements)"""@es;
+  dct:title "Prestación de los servicios públicos de transporte de viajeros por ferrocarril competencia de la AGE, sujetos a OSP en el periodo 2018-2027"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D a
+    epo:MonetaryValue;
+  epo:hasAmountValue 9693759000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Notice a epo:Notice, epo:NoticeT02, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_17f00f55-7178-4597-822a-545d2f55a150_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-05-08T01:01:01+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-tran>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/SPA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "17f00f55-7178-4597-822a-545d2f55a150" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "S 2800113 I" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "AB12345" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/cga>;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Ministerio de Transportes, Movilidad y Agenda Urbana"@es;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Sociedad Mercantil Estatal Renfe Viajeros, Sociedad Anónima"@es;
+  epo:hasPrimaryContactPoint epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_Identifier_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/ESP>,
+    <http://publications.europa.eu/resource/authority/country/FRA>;
+  cccev:registeredAddress epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2;
+  foaf:familyName "Mouse";
+  foaf:givenName "Mickey" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "b11f65a8-81df-4936-838e-01cb93d59111" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "77635" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/60210000> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Any additional information blabla ..."@es;
+  epo:hasInternalIdentifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32007R1370>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/open>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:hasPurpose epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:title "Public transport services by railways"@es;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_17f00f55-7178-4597-822a-545d2f55a150_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0002 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN CON:2020-02/SC" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContract_CON-0001 a epo:Contract;
+  epo:hasContractConclusionDate "2020-04-09+02:00"^^xsd:date;
+  epo:hasLotReference epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  epo:includesTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "TDR ABC:2020-01" .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tender_TEN-0001 a epo:Tender;
+  epo:hasFinancialOfferValue epd:id_17f00f55-7178-4597-822a-545d2f55a150_MonetaryValue_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:isSubmitedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_17f00f55-7178-4597-822a-545d2f55a150_Lot_LOT-0000;
+  adms:identifier epd:id_17f00f55-7178-4597-822a-545d2f55a150_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_17f00f55-7178-4597-822a-545d2f55a150_Organization_ORG-0003 .
+
+epd:id_17f00f55-7178-4597-822a-545d2f55a150_UBOAddress_Kgw52KheiSHAoueYo7YFXX a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ESP>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ES300>;
+  locn:fullAddress "Calle hancha, 78, Madrid, 2836, ESP";
+  locn:postCode "2836";
+  locn:postName "Madrid" .

--- a/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_23/veat_23.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_23/veat_23.ttl
@@ -1,0 +1,279 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AwardDecision_RCZ4KemxRj7U6WkmaKdG6M a
+    epo:AwardDecision;
+  epo:hasAwardDecisionDate "2022-10-25+02:00"^^xsd:date .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  locn:fullAddress "Bahnhofstraße 54, Neckargemünd, 69151, DEU";
+  locn:postCode "69151";
+  locn:postName "Neckargemünd" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Projektmanager NKHR, Controlling";
+  epo:hasFax "+49 6223804-9799";
+  epo:hasInternetAddress "https://www.neckargemuend.de"^^xsd:anyURI;
+  cccev:email "nkhr@neckargemuend.de";
+  cccev:telephone "+49 6223804-701" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+49 62239252-25";
+  cccev:email "info@stadtwerke-neckargemuend.de";
+  cccev:telephone "+49 62239252-0" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128>;
+  locn:address epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Die Stadtwerke Neckargemünd GmbH (SWN) verfügt über zum Teil alleinige Wasserbezugsrechte, die für die Bereitstellung des Trinkwassers zur Versorgung der Stadt Neckargemünd erforderlich sind und über die kein potentieller Wettbewerber verfügt. Denn diese Wasserbezugsrechte sind satzungsrechtlich mit der Mitgliedschaft der SWN in den Zweckverbänden Bodensee-Wasserversorgung und Unteres Elsenztal verknüpft. Mitglied der Zweckverbände ist allein die SWN, nicht die Stadt Neckargemünd, so dass auch keine (auf die Dauer des Konzessionsvertrags befristete) Übertragung dieser Rechte von der Stadt auf das Wasserversorgungsunternehmen möglich ist. Die Rechte stehen allein der SWN kraft ihrer eigenen Mitgliedschaft zu."@de;
+  epo:refersToPreviousProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/65110000> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Konzessionsvertrag: Der Wasser-Konzessionsvertrag enthält neben den Regelungen zur Wegenutzung auch eine Lieferverpflichtung zur Trinkwasserversorgung. Ziel des Vertrages ist es, durch Planung, Bau, Betrieb und Instandhaltung von Wasserversorgungsanlagen unter Nutzung der öffentlichen Verkehrswege der Stadt eine möglichst sichere, preisgünstige, umweltverträgliche und verbraucherfreundliche Versorgung der Einwohner und Gewerbetreibenden im Stadtgebiet von Neckargemünd mit Wasser in guter Qualität zu
+			gewährleisten. Als Entgelt für die eingeräumten Nutzungsrechte sind Konzessionsabgaben im jeweils höchstzulässigen Umfang vereinbart.
+			Der Konzessionsvertrag wird rückwirkend zum 01.01.2022 beginnen und nach 20 Jahren mit Ablauf des 31.12.2041 zunächst enden. Sofern die Stadt nicht kündigt, verlängert sich der Vertrag automatisch um zweimal 10 Jahre. Die Laufzeit beträgt somit bis zu 40 Jahre. Eine gesetzliche festgelegte Maximallaufzeit existiert nicht.
+			Löschwasservereinbarung: Die Stadt Neckargemünd hat gemäß § 3 Absatz 1 Satz 2 Nr. 3 Feuerwehrgesetz Baden-Württemberg (FwG) für die ständige Bereithaltung von Löschwasservorräten zu sorgen. Die der Stadt zur Verfügung stehenden Löschwasserbereitstellungskapazitäten außerhalb der öffentlichen Trinkwasserversorgung reichen nicht aus. Die Stadt ist daher auf die Möglichkeit zur Entnahme von Trinkwasser angewiesen. Der Wasser-Konzessionsvertrag verweist auf die gesonderte Löschwasservereinbarung. In ihr
+			wird geregelt, inwiefern die Stadtwerke Neckargemünd GmbH über das Trinkwassernetz zur Vorhaltung ausreichender Löschwasservorräte im Stadtgebiet beitragen kann und soll.
+			Da die Löschwasservereinbarung an den Wasser-Konzessionsvertrag gekoppelt ist, beginnt und endet sie entsprechend."""@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 10000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Notice a epo:Notice, epo:Notice28, epo:ResultNotice;
+  epo:announcesNoticeAwardInformation epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-01-10T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/DEU>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "9938e0b2-bba7-4123-b96b-a654440660bf" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Stadt Neckargemünd"@de;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "eSendCorp"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0002 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Stadtwerke Neckargemünd GmbH"@de;
+  epo:hasPrimaryContactPoint epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Identifier_ORG-0003 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/DEU>;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "f83d19fa-192f-4eba-acc0-b1a6ac8862c7" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/DE128> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0023>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:hasPurpose epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt;
+  dct:description "Abschluss eines Wasser-Konzessionsvertrags sowie einer Löschwasservereinbarung"@de;
+  dct:title "Wasser-Konzessionsvertrag und Löschwasservereinbarung"@de;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0002;
+  dct:description "ted-esen" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Reviewer_HGvue6GtAm3yppLpDLnBKD a epo:Reviewer;
+  epo:contextualisedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0001 .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContract_CON-0001 a epo:Contract;
+  epo:includesTender epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2023-02" .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Lot_LOT-0000;
+  adms:identifier epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_9938e0b2-bba7-4123-b96b-a654440660bf_Organization_ORG-0003 .

--- a/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_24/veat_24.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_24/veat_24.ttl
@@ -1,0 +1,450 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-04-15+02:00"^^xsd:date .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Bridgend" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Rotherham" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:postCode "ABC123";
+  locn:postName "Caerphilly" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Procurement division";
+  epo:hasFax "+44 16427291779";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "procurement@middlesbrough.gov.uk";
+  cccev:telephone "+44 1642729177" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+44 23232323239";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 2323232323" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+44 12121212129";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 1212121212" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8
+  a cccev:ContactPoint;
+  epo:hasFax "+44 45454545459";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+44 4545454545" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/urgency>;
+  epo:hasJustification """The procurement falls within the remit of regulation 32(2)(c) of the Public Contract Regulations 2015, namely for reasons of extreme urgency brought about by events unforeseeable by the contracting authority.
+			The current contract expires on 30 September 2020.
+			Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+			Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’
+			The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+			(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+			(ii) the modification does not alter the overall nature of the contract;
+			(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+			The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+			The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:refersToPreviousProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0006" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+			Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "DN140070"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 350000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Notice a epo:Notice, epo:Notice25, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_AwardDecision_78uvLikQzydi92srJtY4gJ;
+  epo:announcesNoticeAwardInformation epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-04-23T09:22:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "6ea164b2-228c-4ae8-b3b5-26f3946b8300" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK
+  a epo:OrganisationGroup;
+  epo:hasMember epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004, epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006;
+  epo:leadBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyerid01" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/la>;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Middlesbrough Council"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/gen-pub>;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0002 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0003 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0004 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Direct Healthcare Services Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0004 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/small>;
+  epo:hasLegalName "Harvest Healthcare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0005 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0006 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003;
+  epo:hasBusinessSize <http://publications.europa.eu/resource/authority/economic-operator-size/large>;
+  epo:hasLegalName "Invacare Ltd"@en;
+  epo:hasPrimaryContactPoint epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyContactPoint_exXX5w4R9epdXpscc9vte8;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_CompanyAddress_5oamSpC3ikwoRMLn49RxG2;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Identifier_ORG-0006 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0002 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_59Sg7tGS5qRkCGHeLrco2F .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Person_UBO-0003 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/GBR>;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_BeneficialOwnerTechnicalIdentifier_nwhh7wiDwTuPwa9R3esgw5 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "da39bc05-2d42-4d37-aa4f-2dc9937911a0" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "DN140070" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/33000000> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation """The current contract expires on 30 September 2020.
+		Due to the Covid-19 outbreak, the Council is having to delay some of its procurement activity in order to facilitate its role in dealing with the outbreak, involving some emergency measures, with staff otherwise engaged in procuring more vital services in the current climate.
+		Following the guidance of ‘Procurement Policy Note — Responding to Covid-19 (Information note PPN 01/20: March 2020)’.
+		The Council considers the above to be legal and appropriate under the current circumstances and justified under Regulation 32 of the Public Contract Regulations 2015, in that it is for reasons of extreme urgency brought about by events unforeseeable to the Council and meets the requirements as set out under Regulation 72(1) allowing for the modification of the contract without a new procurement procedure in that the following criteria are all being met:
+		(i) the need for modification has been brought about by circumstances which a diligent contracting authority could not have foreseen;
+		(ii) the modification does not alter the overall nature of the contract;
+		(iii) any increase in price does not exceed 50 % of the value of the original contract or framework agreement.
+		The Council has relied on Regulation 72(1)(c) and is extending the current contract for a period of 6 months until 31 March 2021 and anticipates re-procuring the service and a new contract being in place as from 1 April 2021.
+		The extension of 6 months has been limited to what is absolutely necessary to address the unforeseeable circumstance."""@en;
+  epo:hasInternalIdentifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasPurpose epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description """Beds are to be used in a community setting and must be electrically powered with a range of bed rails, bed rail bumpers and grab handles. Beds size to range from single to bariatric mattresses must be supplied in a range of sizes up to and including king size. Mattresses are to be supplied in the range listed below:
+		Foam Visco/Gel Hybrid (Foam/Air) Alternating Air."""@en;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Tees Valley"@en .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+  epo:contextualisedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Organization_TPO-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "RN AAT-345/02/SC" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  epo:includesTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001;
+  dct:title "Supply of Profiling Beds with Accessories, Pressure Relieving Mattresses and Cushions"@en;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "FGH ABC-2020-02" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tender_TEN-0001 a epo:Tender;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/not-known>;
+  epo:isSubmitedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Lot_LOT-0000;
+  adms:identifier epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_OrganisationGroup_ECUZjDvaPMUJHS4Tp5KyYK .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKC11>;
+  locn:fullAddress "Civic Centre, Middlesbrough, TS1 9FZ, GBR";
+  locn:postCode "TS1 9FZ";
+  locn:postName "Middlesbrough" .
+
+epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "(+44)345678909";
+  epo:hasInternetAddress "https://www.middlesbrough.gov.uk"^^xsd:anyURI;
+  cccev:email "contractandcommissioningunit@middlesbrough.gov.uk";
+  cccev:telephone "(+44)34567890";
+  dct:description "Contract and Commissioning Unit"@en;
+  locn:address epd:id_6ea164b2-228c-4ae8-b3b5-26f3946b8300_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_25/veat_25.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_25/veat_25.ttl
@@ -1,0 +1,367 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW a
+    epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001;
+  epo:hasAwardDecisionDate "2020-03-20+02:00"^^xsd:date .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2
+  a adms:Identifier;
+  epo:hasScheme "ubo";
+  skos:notation "UBO-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "1 Eversholt Street, London, NW1 2DN, GBR";
+  locn:postCode "NW1 2DN";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:postCode "ABC123";
+  locn:postName "London" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/UKI42>;
+  locn:fullAddress "Some Street, Example City, ABC123, GBR";
+  locn:postCode "ABC123";
+  locn:postName "Example City" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasFax "+44 19087810009";
+  epo:hasInternetAddress "https://www.networkrail.co.uk"^^xsd:anyURI;
+  cccev:email "emma.daniels@networkrail.co.uk";
+  cccev:telephone "+44 1908781000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://example.com"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c
+  a cccev:ContactPoint;
+  epo:hasFax "+123 456 7899";
+  epo:hasInternetAddress "https://example-mediator.eu"^^xsd:anyURI;
+  cccev:email "contact@example-mediator.com";
+  cccev:telephone "+123 456 789" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://court.gov.uk"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
+  locn:address epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt
+  a epo:DirectAwardTerm;
+  epo:hasDirectAwardJustification <http://publications.europa.eu/resource/authority/direct-award-justification/exclusive>;
+  epo:hasJustification "Network Rail Infrastructure Ltd (‘NR’) intends to place a contract with the Dreicher and Sohne, Morris Line Engineering and SDCEM Ltd to source remote securing capability to disconnectors fitted across the railway. Competition is absent due to intellectual property rights, compatibility and warranty considerations for the disconnectors already fitted across the network. It is considered that this contract can be placed using the Negotiated Procurement Without Prior Publication pursuant to Article 50 (c) (iii) of Directive 2014/25/EU of the European Parliament and of the Council (Regulation 50 (1) (c) (iii) of the UK Utilities Contracts Regulations 2016) on the basis that the contract may be awarded only to these aforementioned suppliers. The value of the contract is GBP 5 640 000. Please note that this is a voluntary transparency notice and the contracts have not yet been awarded."@en;
+  epo:refersToPreviousProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0004" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0005" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:comprisesTenderAwardOutcome epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001;
+  epo:concernsLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  epo:usesTechnique epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DynamicPurchaseSystemTechnicalUsage_Q4h2gSzyXb646JqueyB5tR;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs a epo:Mediator;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:MonetaryValue;
+  epo:hasAmountValue 5640000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Notice a epo:Notice, epo:Notice26, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_AwardDecision_F4YpWQ6EWfCuYeuwoeaMzW;
+  epo:announcesNoticeAwardInformation epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2020-03-30T05:55:55+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  epo:refersToRole epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation;
+  epo:hasTotalAwardedValue epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_MonetaryValueNoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b9762d53-76dc-427b-9eb8-68e330f854f1" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "buyer" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR
+  a adms:Identifier;
+  skos:notation "court" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE
+  a adms:Identifier;
+  skos:notation "111 111 111" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-cga>;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "Network Rail Infrastructure Ltd"@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/rail>;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_kBS6hfuKcfLdhcriXMzYSR;
+  epo:hasLegalName "Royal Court of Justice"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_n9YzuN82p7GUZfitU2RSTE;
+  epo:hasLegalName "Example Mediator"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NsQgV4dy8XNKVeR2M8tt3c;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_amxyHzzWSDM5hALBwwbWuJ;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0003 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_TiVUHwGQDsX9opwP5GzxJN;
+  epo:hasLegalName "eSendCorp"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_NcbPXevKMmMoUV4ixLLM8J;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_dsV3J5EGaewAFo9YuPgodC;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0004 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 a epo:Business,
+    org:Organization;
+  epo:hasBeneficialOwner epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001;
+  epo:hasLegalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_OrganisationIdentifier_o3DmeDpoFTnKShZ62aR55v;
+  epo:hasLegalName "Dreicher and Sohne"@en;
+  epo:hasPrimaryContactPoint epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyContactPoint_Kt8Anvwo3sjQE2zRaTPDMm;
+  epo:isListedCompany false;
+  cccev:registeredAddress epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_CompanyAddress_Ru6ZF7VecxyPwFsqDRJu85;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Identifier_ORG-0005 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Person_UBO-0001 a person:Person;
+  epo:hasNationality <http://publications.europa.eu/resource/authority/country/LUX>;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_BeneficialOwnerTechnicalIdentifier_BXhK5QPUdH6Cdcb2Cj8MV2 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "7fd26aef-6e07-44a4-9935-1c123fafb47f" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD
+  a adms:Identifier;
+  skos:notation "n/a" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePlacePerformance_Ts6NbgWz9wKHX3CqwnxxzK
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/31214000> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Mediator_Ap5f9znq6VYbCx76JYpsGs .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasAdditionalInformation "Network Rail seeks to retrofit remote securing capability onto existing 25 kV AC disconnector systems already fitted across the network. This activity is essential to protect safety of trackside workers. These items must be sourced from OEM to ensure compatibility and to protect existing warranty for the disconnectors. It is Network Rail's intention to operate a full tender for disconnectors with remote securing technology after this STA as an open competition, contracts will be awarded subject to suppliers receiving product approval."@en;
+  epo:hasInternalIdentifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:hasPurpose epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:isSubjectToProcedureSpecificTerm epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_DirectAwardTerm_DDmVKAr2D9d2R9YAz7bPSt,
+    epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureTerm_eGdkoq4LkbGrncyCWFKjRt;
+  dct:description "This is a voluntary ex ante transparency (VEAT) notice. This notice is to indicate that Network Rail intends to contract with Elektrotechnische werke fritz Driescher and söhne gmbh, Morris Line Engineering and SDCEM, for the purchase of 25 kV AC disconnector motor mechanisms and remote securing modules to be retrofitted onto existing devices on the UK railway network."@en;
+  dct:title "5,640,000"@en;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Procedure_DDmVKAr2D9d2R9YAz7bPSt a epo:Procedure .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "UK Railway infrastructure as maintained by Network Rail."@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ProcurementServiceProvider_AxEoDZth6eN89p7o8GWdBS
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0004;
+  dct:description "ted-esen" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0002 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "CRN ABC/2020-07" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  epo:includesTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D
+  a epo:SubcontractingEstimate;
+  dct:description "The contract/lot/concession is likely to be subcontracted"@en .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderAwardOutcome_TEN-0001 a epo:TenderAwardOutcome;
+  epo:concernsTender epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID ABC/2020-01" .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tender_TEN-0001 a epo:Tender;
+  epo:foreseesSubcontracting epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_SubcontractingEstimate_8tLJD9wyvjSHWYvDWGiX5D;
+  epo:hasSubcontracting <http://publications.europa.eu/resource/authority/applicability/yes>;
+  epo:isSubmitedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Lot_LOT-0000;
+  adms:identifier epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_b9762d53-76dc-427b-9eb8-68e330f854f1_Organization_ORG-0005 .

--- a/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_81/veat_81.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can-1.9/veat_81/veat_81.ttl
@@ -1,0 +1,292 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt a epo:AccessTerm;
+  epo:definesOfflineAccessProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS;
+  epo:definesProcurementProcedureInformationProvider epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001 a epo:AwardDecision;
+  epo:comprisesAwardOutcome epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Buyer_PbuuQVDAP9jvgtF6eprdW2 a epo:Buyer;
+  epo:hasBuyerProfile "https://example.com"^^xsd:anyURI;
+  epo:isContractingEntity true;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/EL303>;
+  locn:fullAddress "Future Solutions Division, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, ZenithNova Innovations 45 Future Boulevard New Horizons, CA 90210 United States of America, New Horizons, CA, 117 43, GRC";
+  locn:postCode "117 43";
+  locn:postName "New Horizons, CA" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GRC>;
+  locn:postName "Patra " .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex
+  a cccev:ContactPoint;
+  epo:hasContactName "Info";
+  epo:hasFax "+1 (555) 123-4567";
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com"^^xsd:anyURI;
+  cccev:email "info@zenithnovainnovations.com";
+  cccev:telephone "+1 (555) 123-4567" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ
+  a cccev:ContactPoint;
+  cccev:email "patra@pat.gr";
+  cccev:telephone "1444452222" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/TON>;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere in the given country"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB a
+    epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP
+  a epo:GreenProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/environmental-impact/circ-econ> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 a adms:Identifier;
+  skos:notation "ORG-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 a adms:Identifier;
+  skos:notation "ORG-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw
+  a epo:InnovativeProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/innovative-acquisition/prod-innov> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0001 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotAwardOutcome_RES-0002 a epo:LotAwardOutcome;
+  epo:concernsLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0002" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AccessTerm_eGdkoq4LkbGrncyCWFKjRt,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43;
+  dct:description """Sinopsis vol2 LOT1 
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT1 """@en;
+  dct:title "Ante nte vol2 LOT1 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_jucn4erQJnXcty2wPoNNzB .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:fulfillsStrategicProcurement epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_GreenProcurement_XZNiSXKnMgRWwd7WMYkYLP,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx;
+  epo:hasInternalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotInternalIdentifier_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotPurpose_Zg4ZmGAZR5g4xA8RP4Bd63;
+  epo:isSubjectToLotSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt;
+  dct:description """Sinopsis vol2 LOT2
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step. The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 LOT2"""@en;
+  dct:title "Ante nte vol2 LOT2"@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Notice a epo:Notice, epo:Notice27, epo:ResultNotice;
+  epo:announcesAwardDecision epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_AwardDecision_CON-0001;
+  epo:announcesNoticeAwardInformation epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
+  epo:announcesRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:hasESenderDispatchDate "2023-05-26T11:16:47Z"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/dir-awa-pre>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/veat>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:refersToProcedure epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt
+  a epo:NoticeAwardInformation .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_NoticeIdentifier_aHt4iskyRUJYALjw7mSMu2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OfflineAccessProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:OfflineAccessProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC
+  a adms:Identifier;
+  skos:notation "ABE" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/spec-rights-entity>;
+  epo:hasLegalIdentifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_OrganisationIdentifier_4NU5AxJwe7aGai3Cgq8HpC;
+  epo:hasLegalName "ZenithNova Innovations Ltd."@en;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/electricity>;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_6r33Cv99oV38zobB7Hepex;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_5w4jTR6gfdXBvGkZDdofo7;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 a epo:Business,
+    org:Organization;
+  epo:hasLegalName "New Org "@en;
+  epo:hasPrimaryContactPoint epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyContactPoint_boyhsCP9AduPpEce9s56fZ;
+  epo:isListedCompany true;
+  cccev:registeredAddress epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_CompanyAddress_QLSEm2DyTzM8ssuHGXE6Hw;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Identifier_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN
+  a adms:Identifier;
+  skos:notation "75db4bef-aae6-41f1-a593-d5dc62abd907" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/73111000> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Procedure_6dcsBnuV4FTNoRpTZHckqN a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32009L0081>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-wo-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001,
+    epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasPurpose epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedurePurpose_Hu2nD8nFQkA5CPSQ43KMRD;
+  dct:description """The 18-year-old freshman Mitsos. The 25-year-old, attached to her parents Sofia. And the 30-year-old just-fine-all-by-myself, Dimitra. A Saturday night when none of them knows if they are ready for the next step.
+vol2 """@en;
+  dct:title "Ante nte vol2 "@en;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcedureIdentifier_6dcsBnuV4FTNoRpTZHckqN .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProcedureInformationProvider_bqHc3E2hNgpWbi57TXQmYS
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_BAFiQAm5eaBz7sDFPbYXor
+  a epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Anywhere"@en .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ProcurementProjectContractTerm_Hu2nD8nFQkA5CPSQ43KMRD
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_QmkiZENjGqABvzebdMdK43 a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_ReviewTerm_hnDhtixV2ZdgbuFJoTT2jt a epo:ReviewTerm;
+  epo:definesReviewer epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Reviewer_bqHc3E2hNgpWbi57TXQmYS a epo:Reviewer;
+  epo:contextualisedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:hasContactPointInRole epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_TPO-0001 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ
+  a adms:Identifier;
+  skos:notation "d1cc5b48-fefc-405f-b888-b0727cd632a0-01" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContract_CON-0001 a epo:Contract;
+  epo:hasLotReference epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001, epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0002;
+  epo:includesTender epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tender_TEN-0001;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SettledContractIdentifier_VPU8QnEnvpxVBA2qwYNzjZ .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_GMkEB6CQmd2Qggut3NjWzr
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/opp> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_SocialProcurement_Kc62R6i3CT36VZoaXkktTx
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/hum-right> .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D
+  a adms:Identifier;
+  skos:notation "BID 123" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tender_TEN-0001 a epo:Tender;
+  epo:isSubmitedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001;
+  epo:isSubmittedForLot epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Lot_LOT-0001;
+  adms:identifier epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TenderIdentifier_8tLJD9wyvjSHWYvDWGiX5D .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Tenderer_TPA-0001 a epo:Tenderer;
+  epo:playedBy epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_Organization_ORG-0002 .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8
+  a locn:Address;
+  locn:fullAddress "Future Solutions Division" .
+
+epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasInternetAddress "https://www.zenithnovainnovations.com/contact-us/katerina-lisa"^^xsd:anyURI;
+  dct:description "Katerina Lisa"@en;
+  locn:address epd:id_cbe9e7b7-6860-4bb1-a200-b3ada0ff6fbe_TouchPointAddress_LdBFAHkYrTBWCThJzAG9g8 .

--- a/mappings/package_can_v1.9/output/sdk_examples_can_invalid-1.9/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
+++ b/mappings/package_can_v1.9/output/sdk_examples_can_invalid-1.9/INVALID_can_24_stage-2/INVALID_can_24_stage-2.ttl
@@ -55,6 +55,9 @@ epd:id__LotIdentifier_jucn4erQJnXcty2wPoNNzB a adms:Identifier;
   epo:hasScheme "Lot";
   skos:notation "" .
 
+epd:id__LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6 a adms:Identifier;
+  skos:notation "" .
+
 epd:id__LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a epo:Purpose .
 
 epd:id__Lot_LOT-0000 a epo:Lot .

--- a/mappings/package_cn_v1.10/output/sdk_examples_cn-1.10/qu-sy_25/qu-sy_25.ttl
+++ b/mappings/package_cn_v1.10/output/sdk_examples_cn-1.10/qu-sy_25/qu-sy_25.ttl
@@ -1,0 +1,332 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/cost>;
+  dct:description "Il prezzo non è il solo criterio di aggiudicazione e tutti i criteri sono indicati solo nei documenti di gara"@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:hasBuyerProfile "https://acquebresciane.acquistitelematici.it"^^xsd:anyURI;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "Acquisti e appalti, via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:postCode "25121";
+  locn:postName "Brescia" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasContactName "Help Desk";
+  epo:hasFax "+39 0307714009";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "acquistiegare@acquebresciane.it";
+  cccev:telephone "+39 03077100" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://example.it"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2020-05-01+02:00"^^xsd:date;
+  epo:hasEnd "2023-04-30+02:00"^^xsd:date .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractPeriod epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasMaximumNumberOfRenewals 0;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/no> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isCoveredByGPA true;
+  epo:isSubjectToLotSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:specifiesProcurementCriterion epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F;
+  epo:usesTechnique epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA a epo:Mediator;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice15;
+  epo:announcesLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:announcesProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG;
+  epo:hasESenderDispatchDate "2020-04-03T12:30:00+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/qu-sy>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ITA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "8439f5f1-ad52-46a0-b363-533779a02e4b" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "Tribunale Amministrativo Regionale" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-ra>;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Acque Bresciane srl"@it;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/water>;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "TAR per la Lombardia — sez. di Brescia"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet;
+  epo:hasLegalName "eSendCorp"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "0bc9e721-7916-4b3d-bbd0-2350efc3f00e" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  epo:isSubjectToProcedureSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/tp-abil>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/sui-act>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/ef-stand>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/ITA> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "+39 030771999";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "contact@acquebresciane.it";
+  cccev:telephone "+39 03077199";
+  dct:description "Responsabile del Procedimento"@it;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY .

--- a/mappings/package_cn_v1.10/output/sdk_examples_cn-1.10/subco_81/subco_81.ttl
+++ b/mappings/package_cn_v1.10/output/sdk_examples_cn-1.10/subco_81/subco_81.ttl
@@ -1,0 +1,307 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_246rmGzZvwFBcxRNZTXjTW a epo:AccessTerm;
+  epo:hasAdditionalInformationDeadline "2023-07-20T17:00:00+02:00"^^xsd:dateTime .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_naE3mfoLZyth2mWXywVhn6 a epo:AccessTerm;
+  epo:hasPublicAccessURL "http://procurement-docs.com"^^xsd:anyURI;
+  epo:isProcurementDocumentRestricted false .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR a
+    epo:EAuctionTechnique;
+  epo:hasUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  dct:description "an electronic auction is used"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/cost>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 100.0;
+  dct:description "The most economically advantageous tender ..."@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Buyer_PbuuQVDAP9jvgtF6eprdW2 a epo:Buyer;
+  epo:hasBuyerProfile "https://publications.europa.eu"^^xsd:anyURI;
+  epo:playedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0001 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:fullAddress "Lekstute, millewee, nonentity, Luxembourg, 1478, LUX";
+  locn:postCode "1478";
+  locn:postName "Luxembourg" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "3333";
+  locn:postName "Luxembourg" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasFax "11111-1";
+  epo:hasInternetAddress "http://pomb.com"^^xsd:anyURI;
+  cccev:email "pomb@mainbuyer.com";
+  cccev:telephone "11111" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "333333-33";
+  epo:hasInternetAddress "http://review.body.com"^^xsd:anyURI;
+  cccev:email "review@email.com";
+  cccev:telephone "333333" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractDuration_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:SpecificDuration;
+  time:numericDuration 36.0;
+  time:unitType time:unitMonth .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  locn:address epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  locn:address epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2023-08-31+02:00"^^xsd:date .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractDuration_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesContractPeriod epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasEOrdering true;
+  epo:hasEPayment true;
+  epo:hasMaximumNumberOfRenewals 2;
+  epo:hasOptionsDescription "The buyer reserves the right for additional purchases from the contractor, as described here (BT-54-Lot"@en;
+  epo:hasPaymentArrangement "Financial arrangement (BT-77-Lot)"@en;
+  epo:hasPerformanceConditions "Conditions relating to the performance of the contract (BT-70-Lot)"@en;
+  epo:hasRenewalDescription "Description of options (BT-57-Lot)"@en;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique;
+  epo:hasDPSScope <http://publications.europa.eu/resource/authority/dps-usage/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an
+  a epo:ExclusionGround;
+  dct:description "See procurement documents"@en;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/bankr-nat> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:FrameworkAgreementTerm;
+  epo:hasFrameworkAgreementType <http://publications.europa.eu/resource/authority/framework-agreement/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_GreenProcurement_VswKT54izDmXgrYjnn32fw
+  a epo:GreenProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/environmental-impact/circ-econ> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0001 a adms:Identifier;
+  skos:notation "ORG-0001" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0002 a adms:Identifier;
+  skos:notation "ORG-0002" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  skos:notation "Internal identifier (BT-22-Lot) *" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/24210000>;
+  epo:hasTotalQuantity epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Quantity_BboGPQkCpLeHXdXL8io8wo .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:fulfillsStrategicProcurement epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_GreenProcurement_VswKT54izDmXgrYjnn32fw,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SocialProcurement_27EJrGiWJjRV4M7z7Bzo6X;
+  epo:hasEstimatedValue epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueLot_EgMjw2pg9jruQvYxRQ9GAr;
+  epo:hasInternalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isRecurrent false;
+  epo:isSubjectToLotSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_246rmGzZvwFBcxRNZTXjTW,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_naE3mfoLZyth2mWXywVhn6, epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NonDisclosureAgreementTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SecurityClearanceTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:isUsingEUFunds false;
+  epo:specifiesProcurementCriterion epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ParticipationCondition_9PH7Nvm6FCPvy2FUmiAo56,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd;
+  epo:usesTechnique epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Description (BT-24-Lot)"@en;
+  dct:title "Title (BT-21-Lot)"@en;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueLot_EgMjw2pg9jruQvYxRQ9GAr
+  a epo:MonetaryValue;
+  epo:hasAmountValue 850.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueProcedure_BaGzsXLuGR4tRgDAxRPwS8
+  a epo:MonetaryValue;
+  epo:hasAmountValue 1000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NonDisclosureAgreementTerm_YWMCGu6i5HBxweh3xaUekn
+  a epo:NonDisclosureAgreementTerm;
+  epo:isNonDisclosureAgreementRequired false .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice22;
+  epo:announcesLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:announcesProcedure epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Buyer_PbuuQVDAP9jvgtF6eprdW2,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C;
+  epo:hasESenderDispatchDate "2023-06-29T07:38:11Z"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/subco>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:refersToProcedure epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b72f5134-7a9c-45d0-b275-fe8b65238c5c" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "33333" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "TRED" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/body-pl>;
+  epo:hasLegalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Private Org main buyer"@en;
+  epo:hasPrimaryContactPoint epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0001 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "Review Body name EN"@en;
+  epo:hasPrimaryContactPoint epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0002 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ParticipationCondition_9PH7Nvm6FCPvy2FUmiAo56
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "8fbc548d-1869-4f6a-9e8a-f4131531228b" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  skos:notation "Internal identifier (BT-22-Procedure)" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/24000000> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasEstimatedValue epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueProcedure_BaGzsXLuGR4tRgDAxRPwS8;
+  epo:hasInternalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32009L0081>;
+  epo:hasMainFeature "Main features of the procedure (BT-88-Procedure)"@en;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:hasPurpose epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  dct:description "Description (BT-24-Procedure)"@en;
+  dct:title "Title (BT-21-Procedure)"@en;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_btiykpkF9yYEWFnDmvRf6a;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Quantity_BboGPQkCpLeHXdXL8io8wo a epo:Quantity;
+  epo:hasQuantityValue 250.0;
+  epo:hasUnitCode <http://publications.europa.eu/resource/authority/measurement-unit/LTR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C a epo:Reviewer;
+  epo:contextualisedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:playedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0002 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SecurityClearanceTerm_YWMCGu6i5HBxweh3xaUekn
+  a epo:SecurityClearanceTerm;
+  epo:isSecurityClearanceRequired true;
+  dct:description "A security clearance is required"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/other>;
+  dct:description "see tender specifications"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SocialProcurement_27EJrGiWJjRV4M7z7Bzo6X
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/acc-all> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:hasEAuctionURL "http://e-auction.com"^^xsd:anyURI;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/DEU>, <http://publications.europa.eu/resource/authority/language/ENG>,
+    <http://publications.europa.eu/resource/authority/language/FRA>, <http://publications.europa.eu/resource/authority/language/LTZ>;
+  epo:hasSubmissionURL "http://e-submission.com"^^xsd:anyURI;
+  epo:isGuaranteeRequired false .

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_maximal/cn_24_maximal.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_maximal/cn_24_maximal.ttl
@@ -30,8 +30,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_Aim3sQTrJD92cok54ZhnWW a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_PuAZ93vcjRYhKiN4rMvUZg a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_RrRXrztPAFwoTrNhP75ZJZ a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -43,8 +43,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_SUjgiTfthNR3jeStaMcRex a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_TT87XZ7rfCixVuS4Z9trMH a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_TTjvk4ng8FHMGggQfNMCNm a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -747,13 +747,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EnvironmentalProtectionInformationProvider_Ap5f9znq6VYbCx76JYpsGs,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Reviewer_6Bv5pbGfbWmvGfJNVgYFXA, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TaxInformationProvider_HaEv2nhsYWgNmx2FoRrNgG,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasESenderDispatchDate "2023-03-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -769,7 +769,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DW
   epo:hasScheme "notice-id";
   skos:notation "14549263-b47b-4e59-96a1-2d0d13e19343" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus
   a epo:OfflineAccessProvider;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0002;
@@ -965,7 +965,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementDocument_oSe2HfMwU4DUDHG6
     <http://publications.europa.eu/resource/authority/language/FRA>;
   epo:hasUnofficialLanguage <http://publications.europa.eu/resource/authority/language/CAT> .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA
   a epo:ProcurementProcedureInformationProvider;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0001;
@@ -1123,8 +1123,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_StrategicProcurement_QRFEJSYy7fATJoZ
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_8y8GPfmPvSRdBcci6WWcSi
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/not-allowed>;
@@ -1141,8 +1141,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_8y8GPfmPvSRdBcci6WWcS
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_daUDPcwCUoxbJRjGb7tKNQ
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -1161,13 +1161,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TaxInformationProvider_HaEv2nhsYWgNm
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:playedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Organization_ORG-0002 .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV
   a epo:TenderProcessor;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0003;
   epo:playedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Organization_TPO-0003 .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA
   a epo:TenderReceiver;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0001;

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_maximal_100_lots/cn_24_maximal_100_lots.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_maximal_100_lots/cn_24_maximal_100_lots.ttl
@@ -49,15 +49,15 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_2W9n6ycxBotkHB635jBbdz a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_2XRCQ8c7wQSncU8gqkmq49 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_2Yu5SnX7DhmJzTPNM4Jxj9 a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_2ZyL89vnyuuuJcaiL4hF9C a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_2j7EUG3bSrY89uV4zvPGdk a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -87,8 +87,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3UDuisaUcABBkWHFMQS5Zq a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3V5odnRtBTtMPAhqpKu3Xf a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3V7m7VSiLCYuo9BHEyLX35 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -109,8 +109,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3mXDcnwD7j5CE3r2r2imdW a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3qSAaGCYd6zG2iENzNGuRt a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_3tFdqtSwjSr6YZ3SypbyBi a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -123,8 +123,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4AkNy8gRWiQhFsiqC7zHvH a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4HbNqsCznx9GSTURSX9zMn a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4PRkrHYMguW3RRTwrp9pGy a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -134,12 +134,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4QHkpwJCq9sXGno9dWkQkW a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4RkdWZMtV64UqYAJ69vb3B a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4hpx2mpmdXTsCzXc9WhmCg a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4t7hKesPHhwgqbuv7BsytL a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -150,8 +150,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_4xeiueNNy5NmhqY5fRnNsa a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_5D4vZJehv6Ew2EqULJSoT2 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_5DVY4NPxGXUbN5hbPhajwm a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -198,12 +198,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_5pXk5uKugJYUWHbxeD84Qq a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_5qdFPBTNJNkKUTc27yXQrr a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_669bfqkDSbEqPGLCARWBZL a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_68Mx5imBjbEvxt2zv8ZqvK a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -214,8 +214,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6EEaeiR4h7vdqYZuGXuXbq a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6GY6tgEvDFvcF4Zc5wxX5C a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6N5aoRRXUxWpraTEeBSRG9 a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -226,8 +226,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6QXLjAdka87TRyahUPwGrh a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6RBsDwdLHFALqeA5oxLNnW a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6c5Z8vFywizLEBHE6Qd4oa a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -240,8 +240,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6dLoiqxCBEWLAMvY3PgVaK a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6hSwH6kctKYKutZUp8gzM5 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6juTapejx9dy8KfALtqd7L a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -249,8 +249,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6juTapejx9dy8KfALtqd7L a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6k2i24Lrn2gwuH27t37GiC a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_6kVEUdmWAUTq5Db683AHWU a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -275,8 +275,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_799s59EBSfQHUUPqkbH46x a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_7D9t4Ew6e6iM8TikdjJksE a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_7FmLPPmYqyA8JvjkUHAG8Y a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -317,8 +317,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_7weHsZwuDAtYLidvUMYpnC a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_7z8dgi6UiHjgi3WaNmpifd a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_7zUgmtqBvKcmGQuWQQw6Bj a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -335,8 +335,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_87YNi3NBhN2FdWKwmvDUGS a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_89WnMkvgBt7mNgKMqcqwqY a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_8C8svLqCDDM6nwDjwuC3jV a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -398,12 +398,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9DjHYZQKaLoTRE2dJbnhWe a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9P9d4n5pYyfPppLM8pzEJG a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9PfxkgmUDwWXRC2KvfNBzx a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9TCTJd2J38MfqnYph4AzBk a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -432,8 +432,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9j3BkphcEhQ4PKKuLZPSoF a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9jSG8DYrGpFcjZy3TU5asa a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9jhKayBFCVx5h2cu3ZZfDF a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -473,8 +473,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9yqrC9Jb8QepoV4fvvjej2 a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_9zhbCK5U8EKD7ak8SRjwuW a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_A3jLmGUpfMXbXRLAMWgyPC a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -491,8 +491,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_A9sgpJpYufrAhYBgfuzSWX a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ACNpThzhm4qX36KDugMCXD a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_AEdkNzieW4qnxgwe67SXYj a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -509,8 +509,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ATGKVG8Xvt5aAzD3UwQmn3 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_AZ6LoXEi6cZ6RooDpKBMe7 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Ahu9LtXTdzX3AHbbEbrrFU a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -534,8 +534,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ApziUhx9Mt9tNaby8P9AcR a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_BBGq3KWQtQ7txAHv7NLeD5 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_BFZSf7FRn3oB3PCZ39YCDr a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -585,8 +585,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_BtwctaQex3CjsTpe2zXiFW a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_C3BEDtmorqf8edVaHSrshc a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_C45j5mg522pqB5rr9afz93 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -612,8 +612,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_CXHXeHQUpEbPtkaVP4KCZo a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_CcFQC6ocLw5nEeDRFFRd2C a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_CjeSoRDGhPv5RMpvCSv2MV a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -630,16 +630,16 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_CrMSLKjjE8UwLy3rqSoZ8k a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_CrQBHdVcfCayVuwgNQF2Vt a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_D3AAUPpyfLvGF8EWHsLJRE a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_D5hyWkXboa5GBWgS6W6mbK a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_DA39dp7kgNCh3DTU8KDvza a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -684,8 +684,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_DgS99DCG8GABZuzDjLpPeB a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_DjVWSsq8yEA4RB7hQPNRZx a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Dmdgu2s8dfrh2QJCwS6M4C a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -711,8 +711,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_E9wkdVXvaCMoEQbduZktqq a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_EDbLEwgM5hzbU9gjgefo3T a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_EG4vC24WE4GquiL9cCDTqv a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -806,8 +806,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_FomWQiCoDDtVPoDHkNnWXq a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_FvNFfTKGQAoKmAFmZWLcTk a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_FzPsMmKPRwpSgc5JPzMzyV a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -838,8 +838,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GJRQhcjwMGZpgMYALZq3cp a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GLspz4RRAoe8WHugAmm6zZ a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GPhEmmoVP5hZo94bVwynTL a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -872,8 +872,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GnGhwsrGdt9GHCedznpsWj a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GvQ7neZT27B8XqpaZUghcQ a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GwiwV3wrBRZXTtYuJHXcd8 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -881,8 +881,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_GwiwV3wrBRZXTtYuJHXcd8 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_H4HdZhdQ7qVgWVksdYerkA a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_HJsJoDzW2Gw5sqbjqdigyb a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -944,8 +944,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_J65zzBJZev76E7g7kWFDfu a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_J9TpuCu3oU3qcaNcR8qKDt a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_JC67HveUGM7YKTdt64DskF a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -992,12 +992,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_JqjyzF6Db4hE5HzsAsA2F5 a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Jsia47rEV3FF5NLbJk9PqM a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_JuhxodNPzMj5rK3xV4VTSg a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_JyXqkdfX2ZRskD3ZVvR3sm a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1058,8 +1058,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_KhAmm2UhJHMFe5xj4WfZ2x a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_KidzAu3JerHmJB8nrQAvVm a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_KrwckHpNn3p3z2P2srmKKe a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1102,12 +1102,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_LSdjpLZJqpRvqwCzRaT9BB a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_LSjXWQk6omG5vvTpjxw5oB a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_LXDJa3ogfm7NeyjNCWpCCc a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_LZbrCyWQHQ9iFmC4PdoYpK a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1124,8 +1124,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Lcns5i9PokLrLvdYQieZ9T a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_LquiXCNxuZCGYowN5Rb9yi a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Lz9eSgS3e5N2FuaRmYjmkg a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1163,8 +1163,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MQiSzUbH3dJ9VANvT4F7nr a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MSvHpbKc7SbVJPgg6RZH3W a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MTo6AwwuAHD2u54xqWN6qD a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1180,8 +1180,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MZYqiVRncRTGCrxM2v744v a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Mab7g9tTdXWsi92RKf5FAp a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MgwHYtgyuaB94wmbFVVpVD a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1208,8 +1208,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_MtpnF2reZsLtg6SViLBuGo a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_N2g7SgwqwnBXC9gKmTmUBc a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_N5Xkm7SZ7kqpA4edRcUpU4 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1227,8 +1227,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_N6y3rodJojqgt26SuwKnnR a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NAsNbJay8YBys2oEkH2XEK a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NEdUjDU28guS2vYramCGMP a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1241,8 +1241,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NEjPneBQ4TbXoCDsC4ipBK a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NGE6BcbJgh2HD42J3Bq3xE a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NJQBmw9CeSgPBBUHo5fUXk a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1274,8 +1274,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NwbXJCeiSFforTxJQbXhQ4 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_NxRW3zqGpAiZwSYa6xyroW a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_P3UxgLa65nxZgor2E77TNT a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1288,8 +1288,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_P6F6N3edkGE22vgi7mLayY a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PLMdAZYRg4Lqfh3QgTAh4S a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PNmmBcCMAyrpiE8b5nreRY a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1312,8 +1312,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PYJTY4X2Uf3MTVAjVAGknW a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PadZYkSYAgKTxCcPtKhSEk a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Pbx2JF4n6rS66vgPWC4Buq epo:hasPublicAccessURL
     "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1340,8 +1340,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PkEXkBJQmS9SudjecApemD a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Pnwk9Aup5LoTZWS3tjnsD6 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PqJUpD8oNvg7zZE2wfKdqy a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1349,8 +1349,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PqJUpD8oNvg7zZE2wfKdqy a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PuAZ93vcjRYhKiN4rMvUZg a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_PyQbapu625gA9nGZQDEQQE a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1372,8 +1372,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_QLjdTe8PtfYGLxWiPCdAjR a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_QT433qA7KzBDig5vttocpb a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_QTMsCcqBzjNDxUs73BWaDy a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1405,12 +1405,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Qz7P36YivKxw3MuFQZAf35 a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_R34TRygQj6gZkK3Par7iDC a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_RBpvrJvjMGAUATiRRKwM9u a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_RESx2kRbLAwispVQfkgFHY a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1473,23 +1473,23 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_RrRXrztPAFwoTrNhP75ZJZ a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_RrezchAg4JaQSCpTz82brz a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Rvvvgu6usapdnykBp8fSvJ a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Rz7Z4HdsVfXsL6v5R7dHYi a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_SAHoEcBcYy5zB5jQfkGPL6 a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_SBxyDxDYnRv2C8vn4b4K7T a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_SGgHrSS5ZkfK3KNe6YCpDY a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1546,12 +1546,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TMvNXSTcpNyQhgyUqdnL5u a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TSWCAEbNJ8Bpr3sSgxYDzv a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TT87XZ7rfCixVuS4Z9trMH a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TTjvk4ng8FHMGggQfNMCNm a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1559,8 +1559,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TTjvk4ng8FHMGggQfNMCNm a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_TeyMiLcMCvPqAPAALGsFY8 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Tr6cPa6kWBTJdknAsddTbn a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1614,8 +1614,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_UtEXn3K2MwWPzB3N5zA5br a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_UtmJRpCKLKxS2jSjkHfc48 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_V7tULu8KkoMmuhPiWYqwqv a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1651,8 +1651,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_WHoamptBXLhjPnRcf7DUSD a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_WNvUZ3VNpgLbiWBxCtSCgq a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_WXbq935drwTs2CBiGXaTYF a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1665,15 +1665,15 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_WoSQugQVMG9BuN2eA92VJu a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Wqj5s4vkDdmX2xSpNaYNsG a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Wr3H9NbYyngrF9smGR8X9E a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_X4bduB4ySCPN9w5g8CDSTV a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_XAejFTmhqwJGwNrgC2UVoP a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1697,8 +1697,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_XZ5foPSqrBE3XGwRa4L4m6 a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Xaf8iTWiztMMLjjGXsRSJs a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_XnxqfcRqzA7sngzwrWyL3G a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1756,8 +1756,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YSVGrDMFMEC9y78st4QztD a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YZ5rxcAwrRvWusnM982kie a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1770,8 +1770,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Ye6vFaVgHG6CRH3k6mgCJk a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YhfrcGQZTAosmXTxVjpGor a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YppqnLuNuLzCkuj2G578C6 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1788,8 +1788,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_YyWYXZaH7fgq9ip5rfEavP a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Z7zoQFcbBMaXtKCHHwMKXE a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZMMGFpHYNdDZQWm5TfRzwa a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1820,8 +1820,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZdMMrzNHSxrNkNeGkyoY9F a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Zj242FuAgr3wkFpmS59RSz a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZjrsCmwiQsRyXTd2fS3eNL a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1833,8 +1833,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Zmitwmt2U7butSsZnJfr9r a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZuyYUmk4Vwo5Cona4nwzAK a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_Zx8R5KNCthkLjhGL69aGoa a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1846,8 +1846,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZxLx8yNN48mUBbsvFyU6rN a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ZzBpCWBRUyGr36mwLUW99Q a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_a6H9HyuXpxQuYMxXzR6gHi a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -1858,8 +1858,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_a93Vx6oeZ3yJkVcKPg33yp a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_a9bFsbNx4H2wPdafxXvcww a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_aGXKaZcPswxMHUaymEmkBW a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1886,8 +1886,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_aiTtK56qQ9C5HxABPByJpj a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_amQDuNnziTZ4Zgmh4nWuKQ a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_anmMEiyHbkNHQt6TeVctw7 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -1957,12 +1957,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_bscuNtMW7EkSuD4Ht84hxi a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_byjdQdHPqZ5Phh559Lqevn a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_bzcAUz4sq2YGvWFjX6JNtD a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_c7eatVLGmZ8SGJMMUfsXxY a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -1986,8 +1986,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_cCfmAbEBqGgHDpstXnXXAJ a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_cLBcScoAoVWHdQeKGX6QEL a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_cMJDmeFrAPuKfNpCBMsLxa a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2055,8 +2055,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_d56w6Gc4ijVKZLqWAiAV75 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_d9VscApCp7gCCGYCD5eWK3 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_dFzUE8nQSmribn42ui46K9 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2074,8 +2074,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_dLSHsKahxzB66dJPhDiiGT a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_dP2oNAWiiMvKk263xfBXBA a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_dW4jrr6kEbQRoqWJs6Es6E a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2093,8 +2093,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_dtjV874kBTCxbSnGCB5WBU a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_e9Q5krTZjn5Qfz2KzBGpTv a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_eCKCKcW4aRkN6bcBRnKgpK a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2141,12 +2141,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_eo9JvyZviVvKR6abwbStQi a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_eyPcnYC3Ujfnd3xa4eLQTP a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ezpckFWcWedN8ERBhBD5yz a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_f2NkWUfiZmKsppNEafcUeK a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2163,8 +2163,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fCpYoWUWRBvKiz6WmxmRAb a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fGknqupLvcCuYbHgdVtFS7 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fHHa5zNc2jy5cUXFhDq6nM a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2177,8 +2177,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fcKzSEzYVtfqXztiDea9U8 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fcXKinfgymeuYUVkN5YG2B a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fcrNYtMKTWufXnVHkbBAob a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2186,16 +2186,16 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fcrNYtMKTWufXnVHkbBAob a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_feR7uzeQ2vKfHYjhX53V8F a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_fzi7LrJiifdSWWsmdnUCoa a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_g3EBGznVKMXLv2sauzz2C3 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_g4KUCNcHf7NLxr3eTHrZq3 a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -2249,8 +2249,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_gsW7ZYwCxS5MCQ49fRkzuH a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_gvk8SmH8tEr4FstiqWZbTU a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_gyrf824bhpnLAEXnZocDKK a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2270,8 +2270,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_h66YGQEcoFB2zW5SJDsnzF a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_hByxcpNfYZphnqk8nmZCL2 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_hRWvSCKQ6VKT9PUpgFJWhb a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2306,8 +2306,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_i6zCsRjqWfLCG5XQuas3Be a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_iCH4tbet8sRT3HL7bGcCfT a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_iEt7tf3iXAfFWBDqgmRhsS a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2344,16 +2344,16 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ivNXL7yQTWNzoaWNJQFGbh a 
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_ixpK3LQycRt9E7ubDYJcrL a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_j2Ryr6bxaQ6iZEUAaSM8se a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
   epo:isProcurementDocumentRestricted true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_j5fqDgr3KwNDfkxATztrB6 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_jDCe5Xyy6RbXr9HwGbMZcz a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2367,8 +2367,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_jKeYhQqhV9oKcmKkcjtmwd a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_jT5PSPh5qSmXDJnQQvgWUv a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_jUxcia5wqWK9XS2w5oMeGD a epo:AccessTerm;
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
@@ -2396,8 +2396,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_jyuBwCkJHHumqG7koMPEBA a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_k7LtrBSaUYvfyjHTB2xpuP a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_kCfEGiMhEnqZ7KvVryuyot a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2419,8 +2419,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_kiys2m7zKjkGQfKJ9iDczv a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_kjdYmC2xMNqBcFB35wVL3r a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_kkCLAcxvaC3LVmJEELTs7F a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2515,8 +2515,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_mrZhum5mDmneFaeLE7xY3j a 
   epo:hasAdditionalInformationDeadline "2023-05-20T20:59:32+01:00"^^xsd:dateTime .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_mspsFkqREFNSphSCWoYLBH a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_mxdYnac49oRFikbepgFaL3 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2524,12 +2524,12 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_mxdYnac49oRFikbepgFaL3 a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_n2CboEyybRQozUB48DDNkp a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_n7VyUrxdh5WCQqE2Dr3azE a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_n8tQv5drfazF7hrNccMG4e a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -2537,8 +2537,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_n8tQv5drfazF7hrNccMG4e a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_nGDPn3h8EL25XFkFjpPBk7 a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_nMSCfb3Ez9vaH3DT4K5xoJ a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -2610,8 +2610,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_oJgqh6Y6GpKxzHm7zWQ2DT a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_oKiUWPit6rKiWjmm3qS9ca a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
-  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesOfflineAccessProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
+  epo:definesProcurementProcedureInformationProvider epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_AccessTerm_oUHv54SLxwtS52U2qbb7DZ a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -20662,13 +20662,13 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Notice a epo:CompetitionNotice, epo:
   epo:announcesRole epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_EnvironmentalProtectionInformationProvider_Ap5f9znq6VYbCx76JYpsGs,
-    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42,
-    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw,
+    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus,
+    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Reviewer_6Bv5pbGfbWmvGfJNVgYFXA, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TaxInformationProvider_HaEv2nhsYWgNmx2FoRrNgG,
-    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK,
-    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV,
+    epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasESenderDispatchDate "2023-03-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -20733,7 +20733,7 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_NoticeIdentifier_cMBzh6pL4JRkiaCd4DW
   epo:hasScheme "notice-id";
   skos:notation "7dac8d90-0883-49f2-87de-519c5992d0bc" .
 
-epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42
+epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus
   a epo:OfflineAccessProvider;
   epo:contextualisedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0001, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0002,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0003, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0004,
@@ -23176,7 +23176,7 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementDocument_oXpiQdyuafZGYebJ
     <http://publications.europa.eu/resource/authority/language/FRA>;
   epo:hasUnofficialLanguage <http://publications.europa.eu/resource/authority/language/CAT> .
 
-epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw
+epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA
   a epo:ProcurementProcedureInformationProvider;
   epo:contextualisedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0001, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0002,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0003, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0004,
@@ -28762,8 +28762,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_StrategicProcurement_o7xXqgEH6zVLXrY
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28779,8 +28779,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_246rmGzZvwFBcxRNZTXjT
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_2Yu5SnX7DhmJzTPNM4Jxj9
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28796,8 +28796,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_2Yu5SnX7DhmJzTPNM4Jxj
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_3QvGCPgbwWdYLGZYCFdjQP
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28813,8 +28813,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_3QvGCPgbwWdYLGZYCFdjQ
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_4PRkrHYMguW3RRTwrp9pGy
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28830,8 +28830,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_4PRkrHYMguW3RRTwrp9pG
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_4t7hKesPHhwgqbuv7BsytL
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28847,8 +28847,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_4t7hKesPHhwgqbuv7Bsyt
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_68Mx5imBjbEvxt2zv8ZqvK
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28864,8 +28864,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_68Mx5imBjbEvxt2zv8Zqv
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_6N5aoRRXUxWpraTEeBSRG9
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28881,8 +28881,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_6N5aoRRXUxWpraTEeBSRG
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_6xwuVvq6NGpVAX7QNbYqjY
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28898,8 +28898,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_6xwuVvq6NGpVAX7QNbYqj
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_7FmLPPmYqyA8JvjkUHAG8Y
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28915,8 +28915,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_7FmLPPmYqyA8JvjkUHAG8
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_8y8GPfmPvSRdBcci6WWcSi
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28932,8 +28932,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_8y8GPfmPvSRdBcci6WWcS
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9DjHYZQKaLoTRE2dJbnhWe
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28948,8 +28948,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9DjHYZQKaLoTRE2dJbnhW
   epo:isMultipleTenderSubmissionAllowed true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9gAFd5nMVfJ99QmREwKMdq
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28966,8 +28966,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9gAFd5nMVfJ99QmREwKMd
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9j3BkphcEhQ4PKKuLZPSoF
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -28983,8 +28983,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9j3BkphcEhQ4PKKuLZPSo
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9nEmjUR6Vq8ktiVijj472t
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29000,8 +29000,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9nEmjUR6Vq8ktiVijj472
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9uPMtQ9bqnW5KkYMmdothK
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29017,8 +29017,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9uPMtQ9bqnW5KkYMmdoth
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9yqrC9Jb8QepoV4fvvjej2
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29034,8 +29034,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_9yqrC9Jb8QepoV4fvvjej
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ahu9LtXTdzX3AHbbEbrrFU
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29051,8 +29051,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ahu9LtXTdzX3AHbbEbrrF
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_BhDEbxUv37DZ5GVYj4voav
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29068,8 +29068,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_BhDEbxUv37DZ5GVYj4voa
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_CTSLCscGyJk65Fj69Nb68S
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29085,8 +29085,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_CTSLCscGyJk65Fj69Nb68
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DEpgp8onG624FKcF3MwEGk
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29102,8 +29102,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DEpgp8onG624FKcF3MwEG
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DGTuanphotWyahPvQvo6N6
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29119,8 +29119,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DGTuanphotWyahPvQvo6N
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DgS99DCG8GABZuzDjLpPeB
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29136,8 +29136,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_DgS99DCG8GABZuzDjLpPe
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_EexPDnePGcdJLVPaJ4dPS7
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29153,8 +29153,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_EexPDnePGcdJLVPaJ4dPS
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_EnRi9aHsb9QY9nCpNEvrL7
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29170,8 +29170,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_EnRi9aHsb9QY9nCpNEvrL
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ewe6UxDbh4a6euvvqA8oVj
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29187,8 +29187,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ewe6UxDbh4a6euvvqA8oV
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FQpkB4Lk7EpvpHehyuEFbb
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29204,8 +29204,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FQpkB4Lk7EpvpHehyuEFb
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FYFC8mEaRrmePqFK4Tt846
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29221,8 +29221,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FYFC8mEaRrmePqFK4Tt84
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FfxmRVmQF5Qr9gioLvXYRP
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29238,8 +29238,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FfxmRVmQF5Qr9gioLvXYR
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FomWQiCoDDtVPoDHkNnWXq
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29255,8 +29255,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_FomWQiCoDDtVPoDHkNnWX
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_GZ9XS9FHoosek6FV8hycYD
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29272,8 +29272,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_GZ9XS9FHoosek6FV8hycY
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_GcZ5p9bkN5W8a6yUj2wZRd
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29289,8 +29289,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_GcZ5p9bkN5W8a6yUj2wZR
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_HNAgRpcY5smtTvihjeqxWg
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29306,8 +29306,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_HNAgRpcY5smtTvihjeqxW
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_HvmBB6e4VcTnhBUZHbas84
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29323,8 +29323,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_HvmBB6e4VcTnhBUZHbas8
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_JSWxhEDYqxkLSs28hjiHcC
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29340,8 +29340,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_JSWxhEDYqxkLSs28hjiHc
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KDpuoXEf9HRbwda2Cqhq2p
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29357,8 +29357,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KDpuoXEf9HRbwda2Cqhq2
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KN5cQYCrPSHpnZEwnAydxG
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29374,8 +29374,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KN5cQYCrPSHpnZEwnAydx
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KrwckHpNn3p3z2P2srmKKe
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29391,8 +29391,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_KrwckHpNn3p3z2P2srmKK
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M3fbCPMrQRiVfF3Q4MBAPT
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29408,8 +29408,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M3fbCPMrQRiVfF3Q4MBAP
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M8cYgtqxLVrrBmHVv7He7x
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29425,8 +29425,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M8cYgtqxLVrrBmHVv7He7
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M9PMjjaAm58L8eHfN2xQaf
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29442,8 +29442,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_M9PMjjaAm58L8eHfN2xQa
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_MDGambT4gjJZtFDSTDJewk
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29459,8 +29459,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_MDGambT4gjJZtFDSTDJew
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_MXTVa8jfnaYkmcqTtu3vaP
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29476,8 +29476,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_MXTVa8jfnaYkmcqTtu3va
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_P3UxgLa65nxZgor2E77TNT
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29493,8 +29493,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_P3UxgLa65nxZgor2E77TN
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_P6F6N3edkGE22vgi7mLayY
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29510,8 +29510,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_P6F6N3edkGE22vgi7mLay
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_PhzVkj7Mcpu5nhoXvB8Hxt
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29527,8 +29527,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_PhzVkj7Mcpu5nhoXvB8Hx
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_QTMsCcqBzjNDxUs73BWaDy
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29544,8 +29544,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_QTMsCcqBzjNDxUs73BWaD
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_QejtDQm6M6xfdTAmHPKchd
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29561,8 +29561,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_QejtDQm6M6xfdTAmHPKch
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Qz7P36YivKxw3MuFQZAf35
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29578,8 +29578,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Qz7P36YivKxw3MuFQZAf3
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_RKEVqhfuxw8U5EiDn9gdRD
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29595,8 +29595,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_RKEVqhfuxw8U5EiDn9gdR
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Rvvvgu6usapdnykBp8fSvJ
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29612,8 +29612,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Rvvvgu6usapdnykBp8fSv
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_T9PuTbSSfHWS5z4AtDcMDq
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29629,8 +29629,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_T9PuTbSSfHWS5z4AtDcMD
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ts5F8Gwx4rX3ei2nvwq4WR
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29646,8 +29646,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Ts5F8Gwx4rX3ei2nvwq4W
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_U78xsnpeiJWMpiwiL4DuAt
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29663,8 +29663,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_U78xsnpeiJWMpiwiL4DuA
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_UkM8TTQrpx8TaKZGK5rQDW
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29680,8 +29680,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_UkM8TTQrpx8TaKZGK5rQD
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_UomCo2QQHiY9vuaFjkzGuz
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29697,8 +29697,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_UomCo2QQHiY9vuaFjkzGu
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_VoYcqEjLBbUmWi6dBHX9te
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29714,8 +29714,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_VoYcqEjLBbUmWi6dBHX9t
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Wr3H9NbYyngrF9smGR8X9E
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29731,8 +29731,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Wr3H9NbYyngrF9smGR8X9
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_XAejFTmhqwJGwNrgC2UVoP
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29748,8 +29748,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_XAejFTmhqwJGwNrgC2UVo
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_XZ5foPSqrBE3XGwRa4L4m6
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29765,8 +29765,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_XZ5foPSqrBE3XGwRa4L4m
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Xw72s5X3pUNfgtSpvLvepE
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29782,8 +29782,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Xw72s5X3pUNfgtSpvLvep
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_YxXPUPXQ4bBvqrJ26NGFwe
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29799,8 +29799,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_YxXPUPXQ4bBvqrJ26NGFw
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Yxt7BkQQyNVgzjgZV7bEkS
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29816,8 +29816,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_Yxt7BkQQyNVgzjgZV7bEk
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_YyWYXZaH7fgq9ip5rfEavP
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29833,8 +29833,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_YyWYXZaH7fgq9ip5rfEav
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZMMGFpHYNdDZQWm5TfRzwa
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29850,8 +29850,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZMMGFpHYNdDZQWm5TfRzw
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZViuyLaDeDW8rDHPBb3FMW
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29867,8 +29867,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZViuyLaDeDW8rDHPBb3FM
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZdHTbNe7dwX5wkyE4UdjZ5
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29884,8 +29884,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ZdHTbNe7dwX5wkyE4UdjZ
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_a6H9HyuXpxQuYMxXzR6gHi
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29901,8 +29901,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_a6H9HyuXpxQuYMxXzR6gH
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_bHqbBs3dwikvBrhjR5wdyV
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29918,8 +29918,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_bHqbBs3dwikvBrhjR5wdy
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_bqbeYVFcvE8K66orK9V6Uj
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29935,8 +29935,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_bqbeYVFcvE8K66orK9V6U
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_c8PUNUAxsqD4hmEDMACF7i
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29952,8 +29952,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_c8PUNUAxsqD4hmEDMACF7
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_cSEMvNhfKnhKQvY4VPdqyM
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29969,8 +29969,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_cSEMvNhfKnhKQvY4VPdqy
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_caVbpX2CZRHBi4mZoUz6gd
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -29986,8 +29986,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_caVbpX2CZRHBi4mZoUz6g
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_dW4jrr6kEbQRoqWJs6Es6E
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30003,8 +30003,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_dW4jrr6kEbQRoqWJs6Es6
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_daUDPcwCUoxbJRjGb7tKNQ
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30019,8 +30019,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_daUDPcwCUoxbJRjGb7tKN
   epo:isMultipleTenderSubmissionAllowed true .
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_eCKCKcW4aRkN6bcBRnKgpK
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30038,8 +30038,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_eCKCKcW4aRkN6bcBRnKgp
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ecPNWW3xWoZTEmU8JgVHVp
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30055,8 +30055,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_ecPNWW3xWoZTEmU8JgVHV
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gDLxeuCFstndFbVLCkMuH7
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30072,8 +30072,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gDLxeuCFstndFbVLCkMuH
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gEvgR73p7bFJsinhAiNu8m
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30089,8 +30089,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gEvgR73p7bFJsinhAiNu8
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gesNcvXQ65gedTyNTo5m9r
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30106,8 +30106,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gesNcvXQ65gedTyNTo5m9
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gyrf824bhpnLAEXnZocDKK
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30123,8 +30123,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_gyrf824bhpnLAEXnZocDK
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_hRWvSCKQ6VKT9PUpgFJWhb
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30140,8 +30140,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_hRWvSCKQ6VKT9PUpgFJWh
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iEt7tf3iXAfFWBDqgmRhsS
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30157,8 +30157,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iEt7tf3iXAfFWBDqgmRhs
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iJpYJ7AuXYfZ8NVPmtSRYA
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30174,8 +30174,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iJpYJ7AuXYfZ8NVPmtSRY
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iQhWy2pRjd7kZfH479dzLQ
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30191,8 +30191,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_iQhWy2pRjd7kZfH479dzL
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_igbbcVoANs5sd8UoLSXF3o
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30208,8 +30208,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_igbbcVoANs5sd8UoLSXF3
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jDCe5Xyy6RbXr9HwGbMZcz
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30225,8 +30225,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jDCe5Xyy6RbXr9HwGbMZc
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jKeYhQqhV9oKcmKkcjtmwd
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30242,8 +30242,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jKeYhQqhV9oKcmKkcjtmw
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jUxcia5wqWK9XS2w5oMeGD
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30259,8 +30259,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jUxcia5wqWK9XS2w5oMeG
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jbnq9ssxcVbDbEWRxft6iW
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30276,8 +30276,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_jbnq9ssxcVbDbEWRxft6i
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_kn6iDhsvj5Aw434uKHZdTn
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30293,8 +30293,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_kn6iDhsvj5Aw434uKHZdT
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_m5ZFVezjkAikFT9DRcboVa
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30310,8 +30310,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_m5ZFVezjkAikFT9DRcboV
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_m7RgfFsvMzReRqNdpJPzsG
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30327,8 +30327,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_m7RgfFsvMzReRqNdpJPzs
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mMFrdNMyrCgcVR6C6bByDt
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30344,8 +30344,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mMFrdNMyrCgcVR6C6bByD
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mZBHTsgMgapyfokBinmdna
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30361,8 +30361,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mZBHTsgMgapyfokBinmdn
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_meF7gyRAcsTqELkiEUf9uN
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30378,8 +30378,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_meF7gyRAcsTqELkiEUf9u
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mmmqxTfT7YbRHaeTxDMXyA
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30395,8 +30395,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mmmqxTfT7YbRHaeTxDMXy
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_modPB8KQ4YYesJczxQcrkw
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30412,8 +30412,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_modPB8KQ4YYesJczxQcrk
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mrZhum5mDmneFaeLE7xY3j
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30429,8 +30429,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_mrZhum5mDmneFaeLE7xY3
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_o49yTGpFFWXcWbzkt4CZCU
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30446,8 +30446,8 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_o49yTGpFFWXcWbzkt4CZC
 
 epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_SubmissionTerm_o9GUccDkHU32sZRBP337aV
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
-  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
+  epo:definesTenderProcessor epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
+  epo:definesTenderReceiver epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -30515,7 +30515,7 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TaxInformationProvider_HaEv2nhsYWgNm
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0099, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0100;
   epo:playedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Organization_ORG-0002 .
 
-epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK
+epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV
   a epo:TenderProcessor;
   epo:contextualisedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0001, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0002,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0003, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0004,
@@ -30570,7 +30570,7 @@ epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderProcessor_76tQtbEmQ5DVqTDsZyL5
   epo:hasContactPointInRole epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TouchPoint_TPO-0003;
   epo:playedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Organization_TPO-0003 .
 
-epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_baYYFs6koZdFUDBjfLzPpw
+epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_TenderReceiver_jwe5W9zs8YV9By53R4pKKA
   a epo:TenderReceiver;
   epo:contextualisedBy epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0001, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0002,
     epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0003, epd:id_7dac8d90-0883-49f2-87de-519c5992d0bc_Lot_LOT-0004,

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_multilingual/cn_24_multilingual.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_multilingual/cn_24_multilingual.ttl
@@ -365,19 +365,7 @@ epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_NoticeIdentifier_cMBzh6pL4JRkiaCd4DW
   skos:notation "55aae64f-88a8-44a5-b2fb-8228e97fe6ee" .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpenTenderEventPlace_JFbBX6QvdBoDFe7oMMpuNc
-  a locn:Address;
-  locn:fullAddress "Помещенията на Службата за публикации в Люксембург."@bg, "Prostory Úřadu pro publikace v Lucemburku."@cs,
-    "Publikationskontorets lokaler i Luxembourg."@da, "Räumlichkeiten des Amtes für Veröffentlichungen in Luxemburg."@de,
-    "Στις εγκαταστάσεις της Υπηρεσίας Εκδόσεων στο Λουξεμβούργο."@el, "Premises of the Publications Office in LUXEMBOURG."@en,
-    "Instalaciones de la Oficina de Publicaciones en Luxemburgo."@es, "Väljaannete talituse ruumid Luxembourgis."@et,
-    "julkaisutoimiston toimitilat Luxemburgissa."@fi, "Locaux de l'Office des publications à Luxembourg."@fr,
-    "Áitreabh Oifig na bhFoilseachán i Lucsamburg."@ga, "Prostori Ureda za publikacije u Luxembourgu."@hr,
-    "A Kiadóhivatal luxembourgi helyiségei."@hu, "Locali dell'Ufficio delle pubblicazioni a Lussemburgo."@it,
-    "Leidinių biuro patalpos Liuksemburge."@lt, "Publikāciju biroja telpas Luksemburgā"@lv,
-    "Il-bini tal-Uffiċċju tal-Pubblikazzjonijiet fil-Lussemburgu."@mt, "de kantoren van het Bureau voor publicaties in Luxemburg."@nl,
-    "siedziba Urzędu Publikacji w Luksemburgu."@pl, "Instalações do Serviço das Publicações em Luxemburgo."@pt,
-    "Sediul Oficiului pentru Publicații din Luxemburg."@ro, "Priestory Úradu pre vydávanie publikácií Európskej únie v Luxemburgu."@sk,
-    "prostori Urada za publikacije v Luxembourgu."@sl, "Publikationsbyråns lokaler i Luxemburg."@sv .
+  a locn:Address .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpeningTerm_SJDjVPGsRNCb7nBWqTThP5 a epo:OpeningTerm;
   epo:definesOpeningPlace epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpenTenderEventPlace_JFbBX6QvdBoDFe7oMMpuNc;
@@ -608,31 +596,7 @@ epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a 
   epo:definesReviewProcedureInformationProvider epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo;
   epo:definesReviewer epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
 
-epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
-  epo:hasReviewDeadlineInformation "В рамките на 2 месеца от получаването на известието от ищеца или, в случай че такова липсва, от деня, в който е станало известно на ищеца. Жалба до Европейския омбудсман нито спира този срок, нито води до откриване на нов срок за подаване на жалби."@bg,
-    "Ve lhůtě 2 měsíců od oznámení žalobci nebo, není-li k dispozici, ode dne, kdy vstoupilo ve známost žalobce. Stížnost podaná evropskému veřejnému ochránci práv nebude mít za následek ani pozastavení této lhůty, ani započetí nové lhůty pro podání odvolání."@cs,
-    "Senest 2 måneder efter meddelelse af klageren eller, i mangel heraf, efter den dag, klageren har taget sagen til efterretning. En klage til Den Europæiske Ombudsmand bevirker ikke, at denne periode afbrydes, eller at der påbegyndes en ny periode for indgivelse af klager."@da,
-    "Binnen 2 Monaten ab Mitteilung an den Kläger oder, in Ermangelung dessen, vom Zeitpunkt der Kenntnisnahme durch den Kläger an. Eine Beschwerde beim Europäischen Bürgerbeauftragten bewirkt weder die Unterbrechung dieses Zeitraums noch den Beginn eines neuen Zeitraums für die Einlegung von Rechtsbehelfen."@de,
-    "Εντός 2 μηνών από την κοινοποίηση στον προσφεύγοντα ή, ελλείψει τέτοιας, από την ημέρα που ο ίδιος έλαβε γνώση. Οι καταγγελίες στον Ευρωπαίο Διαμεσολαβητή δεν έχουν ως αποτέλεσμα ούτε την αναστολή της εν λόγω προθεσμίας ούτε την έναρξη νέας προθεσμίας υποβολής προσφυγών."@el,
-    "Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals."@en,
-    "En un plazo de 2 meses a partir de la notificación al recurrente o, en su defecto, del día en que este haya tenido conocimiento del acto en cuestión. Una reclamación ante el Defensor del Pueblo Europeo no tendrá como efecto la suspensión de dicho plazo ni la apertura de un nuevo plazo de presentación de recursos."@es,
-    "2 kuu jooksul hageja teavitamisest, või kui teavitamist ei toimu, 2 kuu jooksul päevast, mil hageja asjast teada sai. Kaebuse esitamine Euroopa Ombudsmanile ei too kaasa apellatsioonide esitamise tähtaja peatamist ega uue tähtaja määramist."@et,
-    "Muutosta on haettava 2 kuukauden kuluessa ilmoituksesta asianosaiselle tai, jos ilmoitusta ei ole tehty, siitä päivästä, jona asia tuli hänen tietoonsa. Euroopan oikeusasiamiehelle tehty kantelu ei vaikuta määräaikaan, eikä sen vuoksi muutoksenhaulle määrätä uutta määräaikaa."@fi,
-    "Dans les 2 mois à compter de la notification au requérant ou, à défaut, du jour où celui-ci en a eu connaissance. L'introduction d'une plainte auprès du Médiateur européen n'a pour effet ni la suspension de ce délai, ni l'ouverture d'un nouveau délai de recours."@fr,
-    "Laistigh de 2 mhí ón bhfógra chuig an ngearánaí, nó dá éagmais sin, ón lá a tháinig sé chun feasa an ghearánaí. Ní chuirfear an tréimhse sin ar fionraí ná ní thosófar tréimhse nua le haghaidh achomharc a dhéanamh mar thoradh ar ghearán a dhéantar leis an Ombudsman Eorpach."@ga,
-    "U roku od 2 mjeseca od slanja obavijesti podnositelju žalbe, a u slučaju izostanka obavijesti, od datuma primanja na znanje okolnosti koje su povod žalbi. Podnošenjem pritužbe Europskom ombudsmanu to se razdoblje ne obustavlja niti se ne otvara novo razdoblje za podnošenje žalbi."@hr,
-    "A vesztes fél értesítésétől, illetve – ennek hiányában – az eredmény ismertté válásától számított 2 hónapon belül. Az európai ombudsmanhoz benyújtott panasz nem eredményezi sem ezen időszak felfüggesztését, sem új fellebbezési időszak megnyílását."@hu,
-    "Entro 2 mesi dalla notifica al ricorrente o, in assenza, dal giorno in cui ne è venuto a conoscenza. La denuncia al Mediatore europeo non produce né l'effetto di sospendere tale periodo, né di aprirne uno nuovo per la presentazione di ricorsi."@it,
-    "Per 2 mėnesius po to, kai apie tai pranešta ieškovui, arba, jei pranešimas neparengiamas, nuo dienos, kai informacija tampa žinoma. Dėl Europos ombudsmenui pateikto skundo šis laikotarpis nebus sustabdytas ar inicijuotas naujas apeliacijų teikimo laikotarpis."@lt,
-    "2 mēnešu laikā no prasītāja informēšanas vai, ja tā nav notikusi, no dienas, kad prasītājs to uzzinājis. Sūdzības iesniegšana Eiropas Ombudam nevar ne atlikt šo periodu, ne arī atklāt jaunu periodu pārsūdzību iesniegšanai."@lv,
-    "Fi żmien xahrejn (2) mill-avviż li jintbagħat lil min qiegħed iressaq l-ilment, jew, fin-nuqqas ta' dan, mill-jum li fih min qiegħed iressaq l-ilment isir jaf b'dan. It-tressiq ta' lment quddiem l-Ombudsman Ewropew mhux se jkollu effett biex jew jissospendi dan il-perijodu jew biex jinfetaħ perijodu ġdid għat-tressiq tal-appelli."@mt,
-    "Binnen 2 maanden na de kennisgeving aan de klager of, bij ontbreken daarvan, binnen 2 maanden na de dag waarop het de klager bekend werd. Een klacht bij de Europese Ombudsman leidt niet tot een opschorting van die periode, noch tot de opening van een nieuwe periode voor het instellen van een beroep."@nl,
-    "W ciągu 2 miesięcy od zawiadomienia strony skarżącej lub, w przypadku braku zawiadomienia, od dnia podania do wiadomości. Wniesienie skargi do Europejskiego Rzecznika Praw Obywatelskich nie skutkuje zawieszeniem ani rozpoczęciem na nowo biegu terminu składania odwołań."@pl,
-    "Num prazo de 2 meses a contar da data de notificação ao requerente ou, na sua falta, a contar do dia em que o requerente tenha tomado conhecimento do ato. As queixas efetuadas ao Provedor de Justiça Europeu não têm como efeito a suspensão do período em questão, nem a abertura de um novo prazo para a interposição de recursos."@pt,
-    "În termen de 2 luni de la notificarea reclamantului sau, în lipsa acesteia, de la ziua în care acesta a luat cunoștință de actul respectiv. O plângere depusă la Ombudsmanul European nu are drept efect suspendarea acestui termen sau deschiderea unui nou termen pentru utilizarea căilor de atac."@ro,
-    "Do 2 mesiacov od vyrozumenia osoby podávajúcej odvolanie alebo, ak to nie je možné, odo dňa, keď túto skutočnosť zistila. Sťažnosť predložená európskemu ombudsmanovi nebude mať za následok prerušenie tohto obdobia, ani začatie novej lehoty na predloženie odvolaní."@sk,
-    "V 2 mesecih od uradnega obvestila tožniku ali, če tega ni bilo, od dneva, ko je tožnik zanj izvedel. Pritožba Evropskemu varuhu človekovih pravic ne prekine navedenega obdobja niti ne začne novega obdobja za vložitev pritožb."@sl,
-    "Inom 2 månader efter att käranden fick meddelandet eller, om så inte skett, från den dag då käranden fick kännedom om saken. Ett klagomål till Europeiska ombudsmannen leder varken till att denna period avbryts eller till att en ny period för inlämning av ett överklagande inleds."@sv .
+epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
   epo:contextualisedBy epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Lot_LOT-0000;

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_nego_accel/cn_24_nego_accel.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_nego_accel/cn_24_nego_accel.ttl
@@ -277,7 +277,7 @@ epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Notice a epo:CompetitionNotice, epo:
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Mediator_HaEv2nhsYWgNmx2FoRrNgG, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo,
-    epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+    epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
   epo:hasESenderDispatchDate "2020-03-30T09:10:40+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -404,12 +404,12 @@ epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8
 
 epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
   epo:definesReviewProcedureInformationProvider epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo;
-  epo:definesReviewer epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesReviewer epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
   epo:hasReviewDeadlineInformation "There is no right of appeal in this procurement. If you have a complaint or seek to challenge the outcome, please follow the guidance on procedure contained in the previous section."@en .
 
-epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw a epo:Reviewer;
+epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
   epo:contextualisedBy epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TouchPoint_TPO-0001;
   epo:playedBy epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Organization_TPO-0001 .

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_open_accel/cn_24_open_accel.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_24_open_accel/cn_24_open_accel.ttl
@@ -22,7 +22,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
-  epo:definesProcurementProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42 .
+  epo:definesProcurementProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_AccessTerm_naE3mfoLZyth2mWXywVhn6 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://www.carabinieri.it/cittadino/informazioni/gare-appalto/gare-appalto/approvvigionamento-di-212-posti-letto-per-la-scuola-mar.-e-brig.-di-firenze"^^xsd:anyURI;
@@ -277,10 +277,10 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Notice a epo:CompetitionNotice, epo:
   epo:announcesLot epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:announcesProcedure epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Buyer_HGvue6GtAm3yppLpDLnBKD,
-    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Mediator_Ap5f9znq6VYbCx76JYpsGs, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42,
+    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Mediator_Ap5f9znq6VYbCx76JYpsGs, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus,
     epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE,
-    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
   epo:hasESenderDispatchDate "2020-04-23T07:06:04+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -391,7 +391,7 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Procedure_MnX8qyREnFMNLeS5MJAX9K a e
   dct:title "Procedura aperta accelerata per la fornitura di n. 212 posti letto, ognuno composto da arredi e complementi di arredo, per le esigenze della Scuola marescialli e brigadieri di Firenze"@it;
   adms:identifier epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
 
-epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42
+epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus
   a epo:ProcurementProcedureInformationProvider;
   epo:contextualisedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TouchPoint_TPO-0002;
@@ -414,12 +414,12 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_V
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
   epo:definesReviewProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE;
-  epo:definesReviewer epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesReviewer epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
   epo:hasReviewDeadlineInformation "Informazioni dettagliate sui termini di presentazione dei ricorsi:   30 giorni dalla notifica o dall’effettiva conoscenza dell’avvenuta aggiudicazione, per ricorrere al competente Tribunale amministrativo regionale del Lazio, sede di Roma."@it .
 
-epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw a epo:Reviewer;
+epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
   epo:contextualisedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TouchPoint_TPO-0001;
   epo:playedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Organization_TPO-0001 .

--- a/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_25/cn_25.ttl
+++ b/mappings/package_cn_v1.3/output/sdk_examples_cn-1.3/cn_25/cn_25.ttl
@@ -183,7 +183,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000 a epo:Lot;
   dct:title "PV Servicing and Maintenance"@en;
   adms:identifier epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
 
-epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw a epo:Mediator;
+epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA a epo:Mediator;
   epo:contextualisedBy epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_TouchPoint_TPO-0001;
   epo:playedBy epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Organization_TPO-0001 .
@@ -204,7 +204,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Notice a epo:CompetitionNotice, epo:
   epo:announcesLot epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000;
   epo:announcesProcedure epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Buyer_HGvue6GtAm3yppLpDLnBKD,
-    epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw, epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA, epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Reviewer_HaEv2nhsYWgNmx2FoRrNgG;
@@ -284,7 +284,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcedurePurpose_eySzap22e3jkZr3f7VX
 
 epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
     epo:ProcedureTerm;
-  epo:definesMediator epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw .
+  epo:definesMediator epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA .
 
 epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
   epo:foreseesContractSpecificTerm epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,

--- a/mappings/package_cn_v1.8/output/sdk_examples_cn-1.8/qu-sy_25/qu-sy_25.ttl
+++ b/mappings/package_cn_v1.8/output/sdk_examples_cn-1.8/qu-sy_25/qu-sy_25.ttl
@@ -1,0 +1,332 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/cost>;
+  dct:description "Il prezzo non è il solo criterio di aggiudicazione e tutti i criteri sono indicati solo nei documenti di gara"@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:hasBuyerProfile "https://acquebresciane.acquistitelematici.it"^^xsd:anyURI;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "Acquisti e appalti, via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:postCode "25121";
+  locn:postName "Brescia" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasContactName "Help Desk";
+  epo:hasFax "+39 0307714009";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "acquistiegare@acquebresciane.it";
+  cccev:telephone "+39 03077100" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://example.it"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2020-05-01+02:00"^^xsd:date;
+  epo:hasEnd "2023-04-30+02:00"^^xsd:date .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractPeriod epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasMaximumNumberOfRenewals 0;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/no> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isCoveredByGPA true;
+  epo:isSubjectToLotSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:specifiesProcurementCriterion epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F;
+  epo:usesTechnique epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA a epo:Mediator;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice15;
+  epo:announcesLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:announcesProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG;
+  epo:hasESenderDispatchDate "2020-04-03T12:30:00+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/qu-sy>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ITA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "8439f5f1-ad52-46a0-b363-533779a02e4b" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "Tribunale Amministrativo Regionale" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-ra>;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Acque Bresciane srl"@it;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/water>;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "TAR per la Lombardia — sez. di Brescia"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet;
+  epo:hasLegalName "eSendCorp"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "0bc9e721-7916-4b3d-bbd0-2350efc3f00e" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  epo:isSubjectToProcedureSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/tp-abil>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/sui-act>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/ef-stand>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/ITA> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "+39 030771999";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "contact@acquebresciane.it";
+  cccev:telephone "+39 03077199";
+  dct:description "Responsabile del Procedimento"@it;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY .

--- a/mappings/package_cn_v1.9/output/sdk_examples_cn-1.9/qu-sy_25/qu-sy_25.ttl
+++ b/mappings/package_cn_v1.9/output/sdk_examples_cn-1.9/qu-sy_25/qu-sy_25.ttl
@@ -1,0 +1,332 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/cost>;
+  dct:description "Il prezzo non è il solo criterio di aggiudicazione e tutti i criteri sono indicati solo nei documenti di gara"@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:hasBuyerProfile "https://acquebresciane.acquistitelematici.it"^^xsd:anyURI;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "Acquisti e appalti, via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:postCode "25121";
+  locn:postName "Brescia" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasContactName "Help Desk";
+  epo:hasFax "+39 0307714009";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "acquistiegare@acquebresciane.it";
+  cccev:telephone "+39 03077100" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "(+12)345678909";
+  epo:hasInternetAddress "https://example.it"^^xsd:anyURI;
+  cccev:email "contact@example.com";
+  cccev:telephone "(+12)34567890" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2020-05-01+02:00"^^xsd:date;
+  epo:hasEnd "2023-04-30+02:00"^^xsd:date .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractPeriod epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasMaximumNumberOfRenewals 0;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/no> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0000" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isCoveredByGPA true;
+  epo:isSubjectToLotSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AccessTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:specifiesProcurementCriterion epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F;
+  epo:usesTechnique epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA a epo:Mediator;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice15;
+  epo:announcesLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:announcesProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA, epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG;
+  epo:hasESenderDispatchDate "2020-04-03T12:30:00+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/qu-sy>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ITA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:refersToProcedure epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "8439f5f1-ad52-46a0-b363-533779a02e4b" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "Tribunale Amministrativo Regionale" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/pub-undert-ra>;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Acque Bresciane srl"@it;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/water>;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "TAR per la Lombardia — sez. di Brescia"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet;
+  epo:hasLegalName "eSendCorp"@it;
+  epo:hasPrimaryContactPoint epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC;
+  cccev:registeredAddress epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_CompanyAddress_CXdDFvgV5RjePYb9cagtRa;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Identifier_ORG-0003 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 a org:Organization;
+  owl:sameAs epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "0bc9e721-7916-4b3d-bbd0-2350efc3f00e" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  skos:notation "SQASF2020" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45233222> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Mediator_jwe5W9zs8YV9By53R4pKKA .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasAdditionalInformation "A) Controversie. Ai sensi e per gli effetti degli art. 119 e 120 del D.Lgs. 104/2010 e s.m.i. così come recentemente modificato dal codice dei contratti, mediante ricorso al Tribunale amministrativo regionale della Lombardia, sez. di Brescia. Per gli oneri e le tempistiche di impugnazione, posti a pena di inammissibilità del ricorso, si rinvia integralmente a quanto previsto dal predetto art. 120 del D.Lgs. 104/2010 e s.m.i. Tutte le controversie derivanti dall’esecuzione dei contratti afferenti al presente sistema di qualificazione, previo esperimento dei tentativi di transazione e di accordo bonario ai sensi degli art. 205 e 206 del Codice, saranno deferite alla giurisdizione dell’Autorità giudiziaria di Brescia, con esclusione della giurisdizione arbitrale. B) Riserva di aggiudicazione. Acque Bresciane si riserva la facoltà di non procedere agli inviti mediante procedure ristrette/negoziate ai sensi del presente regolamento e di avvalersi per l’aggiudicazione di tali lavori di altre procedure consentite e regolamentate dal codice; Acque Bresciane si riserva, altresì, la facoltà di revocare le successive aggiudicazioni qualora accerti, in qualsiasi momento e con qualunque mezzo di prova, l’assenza di uno o più d’uno dei requisiti minimi richiesti dal presente regolamento, oppure quando accerti una violazione in materia di dichiarazioni, a prescindere dalle verifiche già effettuate, nonché il mancato rispetto della legge n. 136/2010 e s.m.i. C) Trattamento dei dati personali: Acque Bresciane tratterà le informazioni finalizzate all’iscrizione nel «Sistema di qualificazione» nel rispetto dei legittimi interessi dell’operatore economico, riguardante la protezione dei segreti tecnici e commerciali, e della normativa sulla privacy di cui al regolamento europeo n. 2016/679 («GDPR») ed alla normativa applicabile in materia di protezione dei dati personali. Il trattamento suddetto verrà svolto dalla SA secondo le modalità descritte nell’informativa ai sensi dell’art. 13 del GDPR, disponibile sul Portale al seguente indirizzo https://acquebresciane.acquistitelematici.it D) Responsabile del procedimento. Verrà nominato per ciascuna procedura ristretta o negoziata."@it;
+  epo:hasInternalIdentifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0025>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasPurpose epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  epo:isSubjectToProcedureSpecificTerm epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn;
+  dct:description "Acque Bresciane, ai sensi dell’art. 134 del Codice e in conformità a quanto previsto dal regolamento dei contratti, intende istituire un sistema di qualificazione di operatori economici qualificati per l’esecuzione dei lavori di asfaltatura dei rappezzi e delle tracce di scavo derivanti da: — interventi di manutenzione e allacciamenti alle reti di distribuzione acquedotto e fognatura, — estendimenti e/o rifacimenti delle reti di distribuzione acquedotto e fognatura. Il sistema di qualificazione potrà essere utilizzato anche dalle società del gruppo Cogeme e/o da altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata. Il sistema di qualificazione ha lo scopo di: — definire le regole con cui viene istituito e gestito il sistema di qualificazione, i requisiti che devono essere posseduti dagli operatori economici al fine di ottenere la qualificazione e la documentazione comprovante il possesso dei predetti requisiti, — costituire elenchi di operatori economici qualificati nell’attività specifica dei lavori oggetto del presente regolamento e di comprovata idoneità tecnico-professionale (disponibilità minima di mezzi, attrezzature, personale) nell’ambito dei quali la SA, e nell’eventualità le società del gruppo Cogeme (e/o altra società, sempreché controllante o controllata, ai sensi e per gli effetti di cui all’art. 2359 del Codice civile, o comunque partecipante o partecipata) individua i soggetti da invitare — nel rispetto dei principi di non discriminazione, parità di trattamento, proporzionalità, trasparenza e rotazione — alle singole procedure di affidamento di lavori, siano esse procedure ristrette o negoziate di importo inferiore o superiore alla soglia comunitaria. A tali procedure potranno partecipare solo gli operatori economici qualificati, fatto salvo le eccezioni di cui all'art. 10) del regolamento. Il presente regolamento e l’istituzione del sistema di qualificazione non vincolano in alcun modo Acque Bresciane e non costituiscono l’avvio di una procedura di affidamento e/o di aggiudicazione di appalti; il regolamento, l’avviso, le dichiarazioni e la documentazione forniti dagli operatori economici hanno il solo scopo di manifestare la volontà dei medesimi di essere iscritti nel sistema di qualificazione, senza che questo costituisca un vincolo per la SA, atteso che il sistema di qualificazione rappresenta per Acque Bresciane uno strumento da utilizzare, secondo le proprie necessità, per la selezione di operatori economici nell’ambito di affidamento degli appalti appartenenti alle predette categorie di lavori o altre categorie di lavori analoghi e affini. Le disposizioni del presente regolamento devono intendersi sostituite, modificate, abrogate ovvero disapplicate automaticamente ove il relativo contenuto sia incompatibile con sopravvenute inderogabili disposizioni legislative o regolamentari."@it;
+  dct:title "Sistema di qualificazione lavori di asfaltatura dei rappezzi e delle tracce di scavo"@it;
+  adms:identifier epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ContractLocation_btiykpkF9yYEWFnDmvRf6a;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Comuni della Provincia di Brescia il cui elenco è disponibile al link https://www.acquebresciane.it/public/acquebresciane-portal/home/societa/comuni-gestiti."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0003;
+  dct:description "ted-esen" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:hasContactPointInRole epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_TPO-0001 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw;
+  epo:definesReviewer epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Lot_LOT-0000;
+  epo:playedBy epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_Organization_ORG-0002 .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_DEqKehWh2My5y2k7i9vnNu
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/tp-abil>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/sui-act>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/ef-stand>;
+  dct:description "L’istanza di ammissione al sistema di qualificazione è gestita tramite il Portale (https://acquebresciane.acquistitelematici.it) al quale si rinvia per le modalità di registrazione. La procedura di accreditamento è descritta nell'art. 3 del regolamento. Sono ammessi a presentare l’istanza di ammissione al sistema di qualificazione i soggetti di cui all’art. 45 del codice dei contratti. All'art. 5) del regolamento sono elencati i requisiti minimi per accedere al sistema di qualificazione, pena l'esclusione."@it .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/ITA> .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/ITA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/ITC47>;
+  locn:fullAddress "via XXV Aprile 18, Rovato, 25038, ITA";
+  locn:postCode "25038";
+  locn:postName "Rovato" .
+
+epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPoint_TPO-0001 a cccev:ContactPoint;
+  epo:hasFax "+39 030771999";
+  epo:hasInternetAddress "http://www.acquebresciane.it"^^xsd:anyURI;
+  cccev:email "contact@acquebresciane.it";
+  cccev:telephone "+39 03077199";
+  dct:description "Responsabile del Procedimento"@it;
+  locn:address epd:id_8439f5f1-ad52-46a0-b363-533779a02e4b_TouchPointAddress_DQ3D2nHojn4VijYMYRtvzY .

--- a/mappings/package_cn_v1.9/output/sdk_examples_cn-1.9/subco_81/subco_81.ttl
+++ b/mappings/package_cn_v1.9/output/sdk_examples_cn-1.9/subco_81/subco_81.ttl
@@ -1,0 +1,308 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_246rmGzZvwFBcxRNZTXjTW a epo:AccessTerm;
+  epo:hasAdditionalInformationDeadline "2023-07-20T17:00:00+02:00"^^xsd:dateTime .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_naE3mfoLZyth2mWXywVhn6 a epo:AccessTerm;
+  epo:hasPublicAccessURL "http://procurement-docs.com"^^xsd:anyURI;
+  epo:isProcurementDocumentRestricted false .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR a
+    epo:EAuctionTechnique;
+  epo:hasUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  dct:description "an electronic auction is used"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/cost>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 100.0;
+  dct:description "The most economically advantageous tender ..."@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Buyer_PbuuQVDAP9jvgtF6eprdW2 a epo:Buyer;
+  epo:hasBuyerProfile "https://publications.europa.eu"^^xsd:anyURI;
+  epo:playedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0001 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:fullAddress "Lekstute, millewee, nonentity, Luxembourg, 1478, LUX";
+  locn:postCode "1478";
+  locn:postName "Luxembourg" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "3333";
+  locn:postName "Luxembourg" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasFax "11111-1";
+  epo:hasInternetAddress "http://pomb.com"^^xsd:anyURI;
+  cccev:email "pomb@mainbuyer.com";
+  cccev:telephone "11111" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "333333-33";
+  epo:hasInternetAddress "http://review.body.com"^^xsd:anyURI;
+  cccev:email "review@email.com";
+  cccev:telephone "333333" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractDuration_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:SpecificDuration;
+  time:numericDuration 36.0;
+  time:unitType time:unitMonth .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  locn:address epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  locn:address epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2023-08-31+02:00"^^xsd:date .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractDuration epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractDuration_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesContractPeriod epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasEOrdering true;
+  epo:hasEPayment true;
+  epo:hasMaximumNumberOfRenewals 2;
+  epo:hasOptionsDescription "The buyer reserves the right for additional purchases from the contractor, as described here (BT-54-Lot"@en;
+  epo:hasPaymentArrangement "Financial arrangement (BT-77-Lot)"@en;
+  epo:hasPerformanceConditions "Conditions relating to the performance of the contract (BT-70-Lot)"@en;
+  epo:hasRenewalDescription "Description of options (BT-57-Lot)"@en;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique;
+  epo:hasDPSScope <http://publications.europa.eu/resource/authority/dps-usage/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an
+  a epo:ExclusionGround;
+  dct:description "See procurement documents"@en;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/bankr-nat> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:FrameworkAgreementTerm;
+  epo:hasFrameworkAgreementType <http://publications.europa.eu/resource/authority/framework-agreement/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_GreenProcurement_VswKT54izDmXgrYjnn32fw
+  a epo:GreenProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/environmental-impact/circ-econ> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0001 a adms:Identifier;
+  skos:notation "ORG-0001" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0002 a adms:Identifier;
+  skos:notation "ORG-0002" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  skos:notation "Internal identifier (BT-22-Lot) *" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/24210000>;
+  epo:hasTotalQuantity epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Quantity_BboGPQkCpLeHXdXL8io8wo .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:fulfillsStrategicProcurement epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_GreenProcurement_VswKT54izDmXgrYjnn32fw,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SocialProcurement_27EJrGiWJjRV4M7z7Bzo6X;
+  epo:hasEstimatedValue epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueLot_EgMjw2pg9jruQvYxRQ9GAr;
+  epo:hasInternalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isRecurrent false;
+  epo:isSubjectToLotSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_246rmGzZvwFBcxRNZTXjTW,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AccessTerm_naE3mfoLZyth2mWXywVhn6, epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NonDisclosureAgreementTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SecurityClearanceTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:isUsingEUFunds false;
+  epo:specifiesProcurementCriterion epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ParticipationCondition_9PH7Nvm6FCPvy2FUmiAo56,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd;
+  epo:usesTechnique epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Description (BT-24-Lot)"@en;
+  dct:title "Title (BT-21-Lot)"@en;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueLot_EgMjw2pg9jruQvYxRQ9GAr
+  a epo:MonetaryValue;
+  epo:hasAmountValue 850.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueProcedure_BaGzsXLuGR4tRgDAxRPwS8
+  a epo:MonetaryValue;
+  epo:hasAmountValue 1000.0;
+  epo:hasCurrency <http://publications.europa.eu/resource/authority/currency/EUR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NonDisclosureAgreementTerm_YWMCGu6i5HBxweh3xaUekn
+  a epo:NonDisclosureAgreementTerm;
+  epo:isNonDisclosureAgreementRequired false .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice22;
+  epo:announcesLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:announcesProcedure epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Buyer_PbuuQVDAP9jvgtF6eprdW2,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C;
+  epo:hasESenderDispatchDate "2023-06-29T07:38:11Z"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/subco>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:refersToProcedure epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "b72f5134-7a9c-45d0-b275-fe8b65238c5c" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "33333" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "TRED" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/body-pl>;
+  epo:hasLegalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Private Org main buyer"@en;
+  epo:hasPrimaryContactPoint epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0001 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "Review Body name EN"@en;
+  epo:hasPrimaryContactPoint epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Identifier_ORG-0002 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ParticipationCondition_9PH7Nvm6FCPvy2FUmiAo56
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "8fbc548d-1869-4f6a-9e8a-f4131531228b" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  skos:notation "Internal identifier (BT-22-Procedure)" .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/24000000> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasEstimatedValue epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_MonetaryValueProcedure_BaGzsXLuGR4tRgDAxRPwS8;
+  epo:hasInternalIdentifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32009L0081>;
+  epo:hasMainFeature "Main features of the procedure (BT-88-Procedure)"@en;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/neg-w-call>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:hasPurpose epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  dct:description "Description (BT-24-Procedure)"@en;
+  dct:title "Title (BT-21-Procedure)"@en;
+  adms:identifier epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ContractLocation_btiykpkF9yYEWFnDmvRf6a;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/supplies> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Quantity_BboGPQkCpLeHXdXL8io8wo a epo:Quantity;
+  epo:hasQuantityValue 250.0;
+  epo:hasUnitCode <http://publications.europa.eu/resource/authority/measurement-unit/LTR> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewer epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C a epo:Reviewer;
+  epo:contextualisedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Lot_LOT-0001;
+  epo:playedBy epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_Organization_ORG-0002 .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SecurityClearanceTerm_YWMCGu6i5HBxweh3xaUekn
+  a epo:SecurityClearanceTerm;
+  epo:isSecurityClearanceRequired true;
+  dct:description "A security clearance is required"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/other>;
+  dct:description "see tender specifications"@en .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SocialProcurement_27EJrGiWJjRV4M7z7Bzo6X
+  a epo:SocialProcurement;
+  epo:fulfillsRequirement <http://publications.europa.eu/resource/authority/social-objective/acc-all> .
+
+epd:id_b72f5134-7a9c-45d0-b275-fe8b65238c5c_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:hasEAuctionURL "http://e-auction.com"^^xsd:anyURI;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/DEU>, <http://publications.europa.eu/resource/authority/language/ENG>,
+    <http://publications.europa.eu/resource/authority/language/FRA>, <http://publications.europa.eu/resource/authority/language/LTZ>;
+  epo:hasSubmissionURL "http://e-submission.com"^^xsd:anyURI;
+  epo:isGuaranteeRequired false .

--- a/mappings/package_cn_v1.9/output/sdk_examples_cn_invalid-1.9/INVALID_change-cn_24_FRA_comments/INVALID_change-cn_24_FRA_comments.ttl
+++ b/mappings/package_cn_v1.9/output/sdk_examples_cn_invalid-1.9/INVALID_change-cn_24_FRA_comments/INVALID_change-cn_24_FRA_comments.ttl
@@ -1,0 +1,598 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cccev: <http://data.europa.eu/m8g/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epd: <http://data.europa.eu/a4g/resource/> .
+@prefix epo: <http://data.europa.eu/a4g/ontology#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tedm: <http://data.europa.eu/a4g/mapping/sf-rml/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+epd:id_da4d46e9-490b-41ff-a2ae-8166d356a619-01_Notice a epo:Notice;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_NoticeIdentifier_ec9tbJ8ui7TUpJPbEsk6fj .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_TT87XZ7rfCixVuS4Z9trMH a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_XnxqfcRqzA7sngzwrWyL3G a epo:AccessTerm;
+  epo:hasPublicAccessURL "https://www.marches-publics.info/accueil.htm"^^xsd:anyURI;
+  epo:isProcurementDocumentRestricted false .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
+  epo:definesProcurementProcedureInformationProvider epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_naE3mfoLZyth2mWXywVhn6 a epo:AccessTerm;
+  epo:hasPublicAccessURL "https://www.marches-publics.info/accueil.htm"^^xsd:anyURI;
+  epo:isProcurementDocumentRestricted false .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR a
+    epo:EAuctionTechnique;
+  epo:hasUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  dct:description "La solution d’enchères en ligne …"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AuctionTerms_fEtfKJVcbukziY28mGZdui a
+    epo:EAuctionTechnique;
+  epo:hasUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  dct:description "La solution d’enchères en ligne …"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_83TR8A3HiWh9GmZEyyQGjQ
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/quality>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 40.0;
+  dct:description "La valeur technique participle pour 40 % …"@fr;
+  skos:prefLabel "Qualité"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_Ee3JXqpmik8eG35Uay4dJk
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/price>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 60.0;
+  dct:description "Le prix contribue for 40 % …"@fr;
+  skos:prefLabel "Prix"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/price>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 60.0;
+  dct:description "Le prix contribue for 60 % …"@fr;
+  skos:prefLabel "Prix"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_QaDZD9SvbXf8nLh2wqBGkh
+  a epo:AwardCriterion;
+  epo:hasAwardCriterionType <http://publications.europa.eu/resource/authority/award-criterion-type/quality>;
+  epo:hasWeightValueType <http://publications.europa.eu/resource/authority/number-weight/per-exa>;
+  cccev:weight 40.0;
+  dct:description "La valeur technique participle pour 60 % …"@fr;
+  skos:prefLabel "Qualité"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Buyer_HGvue6GtAm3yppLpDLnBKD a epo:Buyer;
+  epo:hasBuyerProfile "http://www.marches-publics.info/accueil.htm"^^xsd:anyURI;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0001 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ChangeInformation_ec9tbJ8ui7TUpJPbEsk6fj
+  a epo:ChangeInformation;
+  epo:concernsNotice epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Notice .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_CXdDFvgV5RjePYb9cagtRa
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/LU000>;
+  locn:postCode "2985";
+  locn:postName "Luxembourg" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_SyrXybB9qnydTsiCYvqfwn
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/FRA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/FRD22>;
+  locn:fullAddress "5 place du Général de Gaulle, Rouen Cedex 1, 76001, FRA";
+  locn:postCode "76001";
+  locn:postName "Rouen Cedex 1" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/FRA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/FRD22>;
+  locn:fullAddress "53 avenue Gustave Flaubert, Rouen, 76000, FRA";
+  locn:postCode "76000";
+  locn:postName "Rouen" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs
+  a cccev:ContactPoint;
+  epo:hasContactName "Info desk";
+  epo:hasFax "+33 235156169";
+  epo:hasInternetAddress "https://www.marches-publics.info/accueil.htm"^^xsd:anyURI;
+  cccev:email "contact@rouenhabitat.fr";
+  cccev:telephone "+33 235156161" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2
+  a cccev:ContactPoint;
+  epo:hasFax "+33 232081279";
+  epo:hasInternetAddress "http://rouen.tribunal-administratif.fr/"^^xsd:anyURI;
+  cccev:email "greffe.ta-rouen@juradm.fr";
+  cccev:telephone "+33 232081270" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC
+  a cccev:ContactPoint;
+  epo:hasFax "+352 1234567899";
+  epo:hasInternetAddress "https://esendercorp.eu"^^xsd:anyURI;
+  cccev:email "esender@example.com";
+  cccev:telephone "+352 123456789" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/FRA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/FRD22> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocationAddress_TfeqsbtZz7bnSaeLJEmaKZ
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/BEL>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/BE100> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_6KLSiuR7u4upEUz8ykdzrc
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/FRA>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/FRD22>;
+  locn:address epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocationAddress_6KLSiuR7u4upEUz8ykdzrc .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/BEL>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/BE100>;
+  locn:address epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocationAddress_TfeqsbtZz7bnSaeLJEmaKZ .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_btiykpkF9yYEWFnDmvRf6a
+  a dct:Location;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/BEL>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/BE100>;
+  locn:address epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC
+  a epo:Period;
+  epo:hasBeginning "2019-09-01+02:00"^^xsd:date;
+  epo:hasEnd "2020-12-31+01:00"^^xsd:date .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
+  a epo:Period;
+  epo:hasBeginning "2019-09-01+02:00"^^xsd:date;
+  epo:hasEnd "2020-12-31+01:00"^^xsd:date .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractTerm_246rmGzZvwFBcxRNZTXjTW a
+    epo:ContractTerm;
+  epo:definesContractPeriod epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractPeriod_DW9uu9Ka9v6eCrwhU9MmBC;
+  epo:definesSpecificPlaceOfPerformance epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_6KLSiuR7u4upEUz8ykdzrc;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/not-allowed>;
+  epo:hasEOrdering false;
+  epo:hasEPayment false;
+  epo:hasMaximumNumberOfRenewals 3;
+  epo:hasOptionsDescription "Options description ---"@fr;
+  epo:hasPlaceOfPerformanceAdditionalInformation "La liste exhaustive des lieux d'exécution se trouve dans le document de consultation intitulé «Décomposition du prix global et forfaitaires (DPGF) lot 1»."@fr;
+  epo:hasRenewalDescription "L'accord-cadre est reconductible de manière tacite, dans les conditions définies au cahier des clauses administratives particulières, 3 fois, pour une période de 12 mois, à compter du 1.1.2021, sans pouvoir excéder le 31.12.2023."@fr;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/no> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
+    epo:ContractTerm;
+  epo:definesContractPeriod epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
+  epo:definesSpecificPlaceOfPerformance epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/works>;
+  epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/not-allowed>;
+  epo:hasEOrdering false;
+  epo:hasEPayment false;
+  epo:hasMaximumNumberOfRenewals 3;
+  epo:hasOptionsDescription "Options description ---"@fr;
+  epo:hasPlaceOfPerformanceAdditionalInformation "La liste exhaustive des lieux d'exécution se trouve dans le document de consultation intitulé «Décomposition du prix global et forfaitaires (DPGF) lot 1»."@fr;
+  epo:hasRenewalDescription "L'accord-cadre est reconductible de manière tacite, dans les conditions définies au cahier des clauses administratives particulières, 3 fois, pour une période de 12 mois, à compter du 1.1.2021, sans pouvoir excéder le 31.12.2023."@fr;
+  epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
+  a epo:DynamicPurchaseSystemTechnique;
+  epo:hasDPSScope <http://publications.europa.eu/resource/authority/dps-usage/none> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:DynamicPurchaseSystemTechnique;
+  epo:hasDPSScope <http://publications.europa.eu/resource/authority/dps-usage/none> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_65B5ieqPopJApHPkYdhiAi
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/socsec-pay> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_BpL5yyeW3cMvEHbh6b4ScW
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/terr-offence> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_LGVLo87ArD4HobVYoAGR5B
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/human-traffic> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_T2q43pjq3JHuJtvxjmL6vf
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/finan-laund> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTD43oQXgzgzeUvR3mf5zL
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/corruption> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTUy3kEUkWQjLYAVZE4jQa
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/envir-law> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TyUFN5TJLPnpNx9yoZf5Ti
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/tax-pay> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/crime-org> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_bm6uSwy7hkcan8rVF5YHgR
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/fraud> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_eE9UGyZshPCAPa9HY5m3SS
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/insolvency> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_gsqwnkSxN5gKbqYWRFqTmc
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/socsec-law> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_hqawu5kJC8i3dxZ99zexxB
+  a epo:ExclusionGround;
+  dct:description "Les critères d'exclusion sont..."@fr;
+  dct:type <http://publications.europa.eu/resource/authority/criterion/labour-law> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_FrameworkAgreementTerm_4qCitbxYVRfdbqxnYtJTZF
+  a epo:FrameworkAgreementTerm;
+  epo:hasFrameworkAgreementType <http://publications.europa.eu/resource/authority/framework-agreement/none> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ
+  a epo:FrameworkAgreementTerm;
+  epo:hasFrameworkAgreementType <http://publications.europa.eu/resource/authority/framework-agreement/none> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0001 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0001" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0002 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0002" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0003 a adms:Identifier;
+  epo:hasScheme "organization";
+  skos:notation "ORG-0003" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotIdentifier_246rmGzZvwFBcxRNZTXjTW a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0001" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ a
+    adms:Identifier;
+  epo:hasScheme "Lot";
+  skos:notation "LOT-0002" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotInternalIdentifier_BDTC4WRLKSCg4KipkdMxR8
+  a adms:Identifier;
+  epo:hasScheme "InternalID";
+  skos:notation "1" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo
+  a adms:Identifier;
+  epo:hasScheme "InternalID";
+  skos:notation "1" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotPurpose_BDTC4WRLKSCg4KipkdMxR8 a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/45310000> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotPurpose_BboGPQkCpLeHXdXL8io8wo a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/77310000> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:hasAdditionalInformation "Il est ici précisé que dans le but de mieux assurer la satisfaction de ses besoins en s'adressant à une pluralité de cocontractants ou de favoriser l'émergence d'une plus grande concurrence, le pouvoir adjudicateur impose une limitation du nombre de lots attribués à 1 pour un même attributaire. La règle d'attribution est explicitée à l'article 3-7 du règlement de la consultation."@fr;
+  epo:hasInternalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotInternalIdentifier_BboGPQkCpLeHXdXL8io8wo;
+  epo:hasPurpose epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotPurpose_BboGPQkCpLeHXdXL8io8wo;
+  epo:isCoveredByGPA true;
+  epo:isSubjectToLotSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_YWMCGu6i5HBxweh3xaUekn,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_naE3mfoLZyth2mWXywVhn6, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_FrameworkAgreementTerm_bq3rWUnhLReULR3Pe8QxDZ,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_GejsGJcoxiEimbiEooTo5B,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW;
+  epo:isUsingEUFunds true;
+  epo:specifiesProcurementCriterion epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_83TR8A3HiWh9GmZEyyQGjQ,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_MGJNUreXVLg5AkPswtTpQ5,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_65B5ieqPopJApHPkYdhiAi,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_BpL5yyeW3cMvEHbh6b4ScW,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_LGVLo87ArD4HobVYoAGR5B,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_T2q43pjq3JHuJtvxjmL6vf,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTD43oQXgzgzeUvR3mf5zL,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTUy3kEUkWQjLYAVZE4jQa,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TyUFN5TJLPnpNx9yoZf5Ti,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_bm6uSwy7hkcan8rVF5YHgR,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_eE9UGyZshPCAPa9HY5m3SS,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_gsqwnkSxN5gKbqYWRFqTmc,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_hqawu5kJC8i3dxZ99zexxB,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F;
+  epo:usesTechnique epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AuctionTerms_Y7WNjU2HSM4HNny2xZsabR,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_DynamicPurchaseSystemTechnicalUsage_bq3rWUnhLReULR3Pe8QxDZ;
+  dct:description "Service d'entretien de remise en état et de nettoyage des espaces verts."@fr;
+  dct:title "Agence centre"@fr;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002 a epo:Lot;
+  epo:foreseesContractSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:hasAdditionalInformation "Il est ici précisé que dans le but de mieux assurer la satisfaction de ses besoins en s'adressant à une pluralité de cocontractants ou de favoriser l'émergence d'une plus grande concurrence, le pouvoir adjudicateur impose une limitation du nombre de lots attribués à 1 pour un même attributaire. La règle d'attribution est explicitée à l'article 3-7 du règlement de la consultation."@fr;
+  epo:hasInternalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotInternalIdentifier_BDTC4WRLKSCg4KipkdMxR8;
+  epo:hasPurpose epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotPurpose_BDTC4WRLKSCg4KipkdMxR8;
+  epo:isCoveredByGPA false;
+  epo:isSubjectToLotSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_TT87XZ7rfCixVuS4Z9trMH,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AccessTerm_XnxqfcRqzA7sngzwrWyL3G, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_FrameworkAgreementTerm_4qCitbxYVRfdbqxnYtJTZF,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_VZxmrBG8UMc3RvpZcKCpvE, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_bMTjo7a5Ke582iB4TXZmU8,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SubmissionTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:isUsingEUFunds true;
+  epo:specifiesProcurementCriterion epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_Ee3JXqpmik8eG35Uay4dJk,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AwardCriterion_QaDZD9SvbXf8nLh2wqBGkh,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_65B5ieqPopJApHPkYdhiAi,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_BpL5yyeW3cMvEHbh6b4ScW,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_LGVLo87ArD4HobVYoAGR5B,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_T2q43pjq3JHuJtvxjmL6vf,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTD43oQXgzgzeUvR3mf5zL,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TTUy3kEUkWQjLYAVZE4jQa,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_TyUFN5TJLPnpNx9yoZf5Ti,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_bm6uSwy7hkcan8rVF5YHgR,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_eE9UGyZshPCAPa9HY5m3SS,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_gsqwnkSxN5gKbqYWRFqTmc,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ExclusionGround_hqawu5kJC8i3dxZ99zexxB,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ParticipationCondition_LRt2DdjrrLdsYp7yMz2y3n,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_Bkpcxn7EFoAsBBzSiUjcX2,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_LPqCAx6u8AHZs68SmxnK7p;
+  epo:usesTechnique epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_AuctionTerms_fEtfKJVcbukziY28mGZdui,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF;
+  dct:description "Service d'entretien de remise en état et de nettoyage des espaces verts."@fr;
+  dct:title "Agence Hauts de Rouen"@fr;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Mediator_HaEv2nhsYWgNmx2FoRrNgG a epo:Mediator;
+  epo:contextualisedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0002 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Notice a epo:CompetitionNotice, epo:Notice,
+    epo:Notice16;
+  epo:announcesLot epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:announcesProcedure epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  epo:announcesRole epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Buyer_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Mediator_HaEv2nhsYWgNmx2FoRrNgG, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Reviewer_HaEv2nhsYWgNmx2FoRrNgG, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+  epo:hasESenderDispatchDate "2019-05-10T00:00:00+01:00"^^xsd:dateTime;
+  epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
+  epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
+  epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/FRA>;
+  epo:hasVersion "01";
+  epo:refersToLot epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:refersToProcedure epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Procedure_MnX8qyREnFMNLeS5MJAX9K;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2
+  a adms:Identifier;
+  epo:hasScheme "notice-id";
+  skos:notation "e887ac08-8b2a-47ee-8ba2-b3564418d241" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_NoticeIdentifier_ec9tbJ8ui7TUpJPbEsk6fj
+  a adms:Identifier;
+  skos:notation "da4d46e9-490b-41ff-a2ae-8166d356a619-01" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk
+  a adms:Identifier;
+  skos:notation "123 456 789" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet
+  a adms:Identifier;
+  skos:notation "111 222 333" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g
+  a adms:Identifier;
+  skos:notation "123 456 789" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0001 a org:Organization;
+  epo:hasBuyerLegalType <http://publications.europa.eu/resource/authority/buyer-legal-type/body-pl>;
+  epo:hasLegalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_ezhXiD7oQurCdTdR4RSM9g;
+  epo:hasLegalName "Rouen Habitat"@fr;
+  epo:hasMainActivity <http://publications.europa.eu/resource/authority/main-activity/education>;
+  epo:hasPrimaryContactPoint epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_7iFD8NVFhULkdXRNPqKyHs;
+  cccev:registeredAddress epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_SyrXybB9qnydTsiCYvqfwn;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0001 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0002 a org:Organization;
+  epo:hasLegalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_ZowVe8fwBUBP7Pd4ikinCk;
+  epo:hasLegalName "Tribunal administratif de Rouen"@fr;
+  epo:hasPrimaryContactPoint epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_CCKfjNm3UAMuYf3dDso6C2;
+  cccev:registeredAddress epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_kp4YHhT2Gw9BnTPKnwxcdW;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0002 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0003 a org:Organization;
+  epo:hasLegalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_OrganisationIdentifier_dcFQz5DL4ZBPqMeq5T8Yet;
+  epo:hasLegalName "eSendCorp"@fr;
+  epo:hasPrimaryContactPoint epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyContactPoint_YG3RWHcWTBZPCNqFAQ7guC;
+  cccev:registeredAddress epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_CompanyAddress_CXdDFvgV5RjePYb9cagtRa;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Identifier_ORG-0003 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ParticipationCondition_LRt2DdjrrLdsYp7yMz2y3n
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/res-ws> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ParticipationCondition_Wbukq4uv37BmR2FRZxpHbN
+  a epo:ParticipationCondition;
+  epo:hasReservedProcurement <http://publications.europa.eu/resource/authority/reserved-procurement/none> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K
+  a adms:Identifier;
+  skos:notation "9999abf1-e057-47a5-9210-b1f6fc759999" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj
+  a adms:Identifier;
+  epo:hasScheme "InternalID";
+  skos:notation "19S0001" .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedurePlacePerformance_btiykpkF9yYEWFnDmvRf6a
+  a locn:Address;
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/BEL>;
+  epo:hasNutsCode <http://data.europa.eu/nuts/code/BE100> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj
+  a epo:Purpose;
+  epo:hasMainClassification <http://data.europa.eu/cpv/cpv/77320000> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_BniuuBzYtT7voNxpkh6A9M a
+    epo:ProcedureTerm;
+  epo:hasMaximumLotSubmissionAllowed 1;
+  epo:hasMaximumNumberOfLotsToBeAwarded 0 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_MnX8qyREnFMNLeS5MJAX9K a
+    epo:ProcedureTerm;
+  epo:isSubmissionForAllLotsRequired true .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_TT87XZ7rfCixVuS4Z9trMH a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
+    epo:ProcedureTerm;
+  epo:definesMediator epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Mediator_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
+  epo:foreseesContractSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj;
+  epo:hasInternalIdentifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureIdentifier_eySzap22e3jkZr3f7VXYNj;
+  epo:hasLegalBasis <http://publications.europa.eu/resource/authority/legal-basis/32014L0024>;
+  epo:hasProcedureType <http://publications.europa.eu/resource/authority/procurement-procedure-type/oth-single>;
+  epo:hasProcurementScopeDividedIntoLot epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:hasPurpose epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedurePurpose_eySzap22e3jkZr3f7VXYNj;
+  epo:isSubjectToProcedureSpecificTerm epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_BniuuBzYtT7voNxpkh6A9M,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_MnX8qyREnFMNLeS5MJAX9K,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_TT87XZ7rfCixVuS4Z9trMH,
+    epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn;
+  dct:description "Service d'entretien de remise en état et de nettoyage des espaces verts."@fr;
+  dct:title "Service d'entretien de remise en état et de nettoyage des espaces verts"@fr;
+  adms:identifier epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD
+  a epo:ProcurementProcedureInformationProvider;
+  epo:contextualisedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0001 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx
+  a epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ContractLocation_btiykpkF9yYEWFnDmvRf6a .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementProjectContractTerm_eySzap22e3jkZr3f7VXYNj
+  a epo:ContractTerm;
+  epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m
+  a epo:ProcurementServiceProvider;
+  epo:actsOnBehalfOf epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Buyer_HGvue6GtAm3yppLpDLnBKD;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0003 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE
+  a epo:ReviewProcedureInformationProvider;
+  epo:contextualisedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0002 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE;
+  epo:definesReviewer epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
+  epo:hasReviewDeadlineInformation "Toute demande de revision doit être …"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_VZxmrBG8UMc3RvpZcKCpvE a epo:ReviewTerm;
+  epo:hasReviewDeadlineInformation "Toute demande de revision doit être …"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewTerm_bMTjo7a5Ke582iB4TXZmU8 a epo:ReviewTerm;
+  epo:definesReviewProcedureInformationProvider epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE;
+  epo:definesReviewer epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
+  epo:contextualisedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0002 .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_Bkpcxn7EFoAsBBzSiUjcX2
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/ef-stand>;
+  dct:description "Critères de sélection tels que mentionnés dans les documents de la consultation"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_F2EkrTHhwGTB3ZRA69q4nd
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/ef-stand>;
+  dct:description "Critères de sélection tels que mentionnés dans les documents de la consultation"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_LPqCAx6u8AHZs68SmxnK7p
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/tp-abil>;
+  dct:description "Critères de sélection tels que mentionnés dans les documents de la consultation"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SelectionCriterion_QwLGZTLYe95szz5vdsUu7F
+  a epo:SelectionCriterion;
+  epo:hasSelectionCriteriaUsage <http://publications.europa.eu/resource/authority/usage/used>;
+  epo:hasSelectionCriterionType <http://publications.europa.eu/resource/authority/selection-criterion/tp-abil>;
+  dct:description "Critères de sélection tels que mentionnés dans les documents de la consultation"@fr .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SubmissionTerm_246rmGzZvwFBcxRNZTXjTW
+  a epo:SubmissionTerm;
+  epo:definesTenderReceiver epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+  epo:hasEAuctionURL "https://my-online-eauction.eu/"^^xsd:anyURI;
+  epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/FRA>;
+  epo:hasReceiptTenderDeadline "2019-06-24ZT16:00:00Z"^^xsd:dateTime;
+  epo:hasSubmissionURL "https://www.marches-publics.info/accueil.htm"^^xsd:anyURI .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_SubmissionTerm_daUDPcwCUoxbJRjGb7tKNQ
+  a epo:SubmissionTerm;
+  epo:definesTenderReceiver epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+  epo:hasEAuctionURL "https://my-online-eauction.eu/"^^xsd:anyURI;
+  epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/allowed>;
+  epo:hasLanguage <http://publications.europa.eu/resource/authority/language/FRA>;
+  epo:hasReceiptTenderDeadline "2019-06-24ZT16:00:00Z"^^xsd:dateTime;
+  epo:hasSubmissionURL "https://www.marches-publics.info/accueil.htm"^^xsd:anyURI .
+
+epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_TenderReceiver_HGvue6GtAm3yppLpDLnBKD
+  a epo:TenderReceiver;
+  epo:contextualisedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0001, epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Lot_LOT-0002;
+  epo:playedBy epd:id_e887ac08-8b2a-47ee-8ba2-b3564418d241_Organization_ORG-0001 .


### PR DESCRIPTION
All changes relate to the following kinds of actions:

- Updating to the latest eForms SDK patch version
- Fixing some mismatching versions owing to past human error
- Fixing INVALID example data for parity with the eForms SDK
- Introducing new example data for extended coverage in new exercises

None of the outputs relate to any change in mapping rules and therefore transformation behaviour is in tact.