### PR TITLE
Update version of a Github action to fix CI build error

### DIFF
--- a/.github/workflows/antora-worflow.yml
+++ b/.github/workflows/antora-worflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Install Node 16"
         uses: actions/setup-node@v3
         with:
@@ -20,7 +20,7 @@ jobs:
       - name: "Generate site using antora site action"
         run: make build-site
       - name: "Upload generated site"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: site
           path: "${{ github.workspace }}/build/${{ env.SITE_DIR }}"
@@ -37,9 +37,9 @@ jobs:
         with:
           node-version: 16
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download generated site
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: site
           path: "${{ github.workspace }}/${{ env.SITE_DIR }}"

--- a/.github/workflows/antora-worflow.yml
+++ b/.github/workflows/antora-worflow.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ master, main, develop ]
+    branches: [ master, main, develop, fix-ci ]
 env:
   SITE_DIR: 'site'
 jobs:

--- a/.github/workflows/antora-worflow.yml
+++ b/.github/workflows/antora-worflow.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ master, main, develop, fix-ci ]
+    branches: [ master, main, develop ]
 env:
   SITE_DIR: 'site'
 jobs:


### PR DESCRIPTION
Version of the `upload-artifact` Github action has been updated to fix the CI build error:

```Error: Missing download info for actions/upload-artifact@v3```

A few other old versions have been updated as well as the versions < 4 are considered deprecated (shouldn't be used).