### PR TITLE
Retraction of SDK v1.3 patch update and absent language tag fix

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.10_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "9e6346d156463b548213c12a8318bf42150e92278792a53222ba289cf8298cea"
+    "mapping_suite_hash_digest": "06618376218bc68f1b17e3affc9f51a5c8737264bc642d16e1cca88275bf7e69"
 }

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.8" ;
             tedm:maxSDKVersion "1.11" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.11_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "616d1ed66c68992f397cc5c1e6676afa64b475a0e33179f704a401497040068f"
+    "mapping_suite_hash_digest": "86d8115fce39c79dfe468689d02ff14f202928846e9826eef5136374e5973c48"
 }

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.11-1.11.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.11-1.11.rml.ttl
@@ -68,7 +68,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.8" ;
             tedm:maxSDKVersion "1.11" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.12_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "084a76113642f0845c2025edcf18723ba906f5bc5e8122bf42d7ca1293d169e5"
+    "mapping_suite_hash_digest": "1f7569b93f9cc411f42af5938686dadc0923b9cd8e6d45f7d8004494564fddb1"
 }

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot_v1.12+.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot_v1.12+.rml.ttl
@@ -88,7 +88,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -161,7 +161,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:predicate epo-not:hasLateSubmissionInformationDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.12" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.13_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "068823824ba3c84d2e69a2854e69c861a03b7b164c36043aada2a3931ba505f1"
+    "mapping_suite_hash_digest": "ce1d06cad43f04c71cc611b6b08028882075c55acb761a54bf9ad742803c5071"
 }

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot_v1.12+.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot_v1.12+.rml.ttl
@@ -88,7 +88,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -161,7 +161,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:predicate epo-not:hasLateSubmissionInformationDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.12" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.3_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "f9cce63776683f50c5ced432153e925d7457117754c4fcfdc94a525829363768"
+    "mapping_suite_hash_digest": "0c08d2c01db63426459f2d70e99526ce7ab39a0e5772667c04ce6c5b7a55cacf"
 }

--- a/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_maximal/cn_24_maximal.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_maximal/cn_24_maximal.ttl
@@ -30,8 +30,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_Aim3sQTrJD92cok54ZhnWW a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_PuAZ93vcjRYhKiN4rMvUZg a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
-  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
+  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
+  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_RrRXrztPAFwoTrNhP75ZJZ a epo:AccessTerm;
   epo:hasRestrictedAccessURL "http://accessto.com"^^xsd:anyURI;
@@ -43,8 +43,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_SUjgiTfthNR3jeStaMcRex a 
   epo:isProcurementDocumentRestricted false .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_TT87XZ7rfCixVuS4Z9trMH a epo:AccessTerm;
-  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus;
-  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA .
+  epo:definesOfflineAccessProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42;
+  epo:definesProcurementProcedureInformationProvider epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_AccessTerm_TTjvk4ng8FHMGggQfNMCNm a epo:AccessTerm;
   epo:hasPublicAccessURL "http://nonrestricteddocuments.com"^^xsd:anyURI;
@@ -747,13 +747,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EnvironmentalProtectionInformationProvider_Ap5f9znq6VYbCx76JYpsGs,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Mediator_Db3VnFcw2TfRM6Qmj79Ari, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ReviewProcedureInformationProvider_NLBDyF4vvGuCAMJpQJe8nw,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Reviewer_6Bv5pbGfbWmvGfJNVgYFXA, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TaxInformationProvider_HaEv2nhsYWgNmx2FoRrNgG,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
   epo:hasESenderDispatchDate "2023-03-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -769,7 +769,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DW
   epo:hasScheme "notice-id";
   skos:notation "14549263-b47b-4e59-96a1-2d0d13e19343" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_oBahBtUnPsC7aJgntGEdus
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_OfflineAccessProvider_awAJeTbTwyjSCKucPVAp42
   a epo:OfflineAccessProvider;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0002;
@@ -965,7 +965,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementDocument_oSe2HfMwU4DUDHG6
     <http://publications.europa.eu/resource/authority/language/FRA>;
   epo:hasUnofficialLanguage <http://publications.europa.eu/resource/authority/language/CAT> .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_jwe5W9zs8YV9By53R4pKKA
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ProcurementProcedureInformationProvider_baYYFs6koZdFUDBjfLzPpw
   a epo:ProcurementProcedureInformationProvider;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0001;
@@ -1123,8 +1123,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_StrategicProcurement_QRFEJSYy7fATJoZ
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_8y8GPfmPvSRdBcci6WWcSi
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
-  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
+  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
+  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/not-allowed>;
@@ -1141,8 +1141,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_8y8GPfmPvSRdBcci6WWcS
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SubmissionTerm_daUDPcwCUoxbJRjGb7tKNQ
   a epo:SubmissionTerm;
-  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV;
-  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA;
+  epo:definesTenderProcessor epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK;
+  epo:definesTenderReceiver epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw;
   epo:hasEAuctionURL "https://electronic-auction.com"^^xsd:anyURI;
   epo:hasECataloguePermission <http://publications.europa.eu/resource/authority/permission/allowed>;
   epo:hasESubmissionPermission <http://publications.europa.eu/resource/authority/permission/required>;
@@ -1161,13 +1161,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TaxInformationProvider_HaEv2nhsYWgNm
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:playedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Organization_ORG-0002 .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_4WTrJp45AQtaBQXEMy6VfV
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderProcessor_76tQtbEmQ5DVqTDsZyL5SK
   a epo:TenderProcessor;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0003;
   epo:playedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Organization_TPO-0003 .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_jwe5W9zs8YV9By53R4pKKA
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TenderReceiver_baYYFs6koZdFUDBjfLzPpw
   a epo:TenderReceiver;
   epo:contextualisedBy epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
   epo:hasContactPointInRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_TouchPoint_TPO-0001;

--- a/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_multilingual/cn_24_multilingual.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_multilingual/cn_24_multilingual.ttl
@@ -365,7 +365,19 @@ epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_NoticeIdentifier_cMBzh6pL4JRkiaCd4DW
   skos:notation "55aae64f-88a8-44a5-b2fb-8228e97fe6ee" .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpenTenderEventPlace_JFbBX6QvdBoDFe7oMMpuNc
-  a locn:Address .
+  a locn:Address;
+  locn:fullAddress "Помещенията на Службата за публикации в Люксембург."@bg, "Prostory Úřadu pro publikace v Lucemburku."@cs,
+    "Publikationskontorets lokaler i Luxembourg."@da, "Räumlichkeiten des Amtes für Veröffentlichungen in Luxemburg."@de,
+    "Στις εγκαταστάσεις της Υπηρεσίας Εκδόσεων στο Λουξεμβούργο."@el, "Premises of the Publications Office in LUXEMBOURG."@en,
+    "Instalaciones de la Oficina de Publicaciones en Luxemburgo."@es, "Väljaannete talituse ruumid Luxembourgis."@et,
+    "julkaisutoimiston toimitilat Luxemburgissa."@fi, "Locaux de l'Office des publications à Luxembourg."@fr,
+    "Áitreabh Oifig na bhFoilseachán i Lucsamburg."@ga, "Prostori Ureda za publikacije u Luxembourgu."@hr,
+    "A Kiadóhivatal luxembourgi helyiségei."@hu, "Locali dell'Ufficio delle pubblicazioni a Lussemburgo."@it,
+    "Leidinių biuro patalpos Liuksemburge."@lt, "Publikāciju biroja telpas Luksemburgā"@lv,
+    "Il-bini tal-Uffiċċju tal-Pubblikazzjonijiet fil-Lussemburgu."@mt, "de kantoren van het Bureau voor publicaties in Luxemburg."@nl,
+    "siedziba Urzędu Publikacji w Luksemburgu."@pl, "Instalações do Serviço das Publicações em Luxemburgo."@pt,
+    "Sediul Oficiului pentru Publicații din Luxemburg."@ro, "Priestory Úradu pre vydávanie publikácií Európskej únie v Luxemburgu."@sk,
+    "prostori Urada za publikacije v Luxembourgu."@sl, "Publikationsbyråns lokaler i Luxemburg."@sv .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpeningTerm_SJDjVPGsRNCb7nBWqTThP5 a epo:OpeningTerm;
   epo:definesOpeningPlace epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_OpenTenderEventPlace_JFbBX6QvdBoDFe7oMMpuNc;
@@ -596,7 +608,31 @@ epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a 
   epo:definesReviewProcedureInformationProvider epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo;
   epo:definesReviewer epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Reviewer_HaEv2nhsYWgNmx2FoRrNgG .
 
-epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm .
+epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
+  epo:hasReviewDeadlineInformation "В рамките на 2 месеца от получаването на известието от ищеца или, в случай че такова липсва, от деня, в който е станало известно на ищеца. Жалба до Европейския омбудсман нито спира този срок, нито води до откриване на нов срок за подаване на жалби."@bg,
+    "Ve lhůtě 2 měsíců od oznámení žalobci nebo, není-li k dispozici, ode dne, kdy vstoupilo ve známost žalobce. Stížnost podaná evropskému veřejnému ochránci práv nebude mít za následek ani pozastavení této lhůty, ani započetí nové lhůty pro podání odvolání."@cs,
+    "Senest 2 måneder efter meddelelse af klageren eller, i mangel heraf, efter den dag, klageren har taget sagen til efterretning. En klage til Den Europæiske Ombudsmand bevirker ikke, at denne periode afbrydes, eller at der påbegyndes en ny periode for indgivelse af klager."@da,
+    "Binnen 2 Monaten ab Mitteilung an den Kläger oder, in Ermangelung dessen, vom Zeitpunkt der Kenntnisnahme durch den Kläger an. Eine Beschwerde beim Europäischen Bürgerbeauftragten bewirkt weder die Unterbrechung dieses Zeitraums noch den Beginn eines neuen Zeitraums für die Einlegung von Rechtsbehelfen."@de,
+    "Εντός 2 μηνών από την κοινοποίηση στον προσφεύγοντα ή, ελλείψει τέτοιας, από την ημέρα που ο ίδιος έλαβε γνώση. Οι καταγγελίες στον Ευρωπαίο Διαμεσολαβητή δεν έχουν ως αποτέλεσμα ούτε την αναστολή της εν λόγω προθεσμίας ούτε την έναρξη νέας προθεσμίας υποβολής προσφυγών."@el,
+    "Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals."@en,
+    "En un plazo de 2 meses a partir de la notificación al recurrente o, en su defecto, del día en que este haya tenido conocimiento del acto en cuestión. Una reclamación ante el Defensor del Pueblo Europeo no tendrá como efecto la suspensión de dicho plazo ni la apertura de un nuevo plazo de presentación de recursos."@es,
+    "2 kuu jooksul hageja teavitamisest, või kui teavitamist ei toimu, 2 kuu jooksul päevast, mil hageja asjast teada sai. Kaebuse esitamine Euroopa Ombudsmanile ei too kaasa apellatsioonide esitamise tähtaja peatamist ega uue tähtaja määramist."@et,
+    "Muutosta on haettava 2 kuukauden kuluessa ilmoituksesta asianosaiselle tai, jos ilmoitusta ei ole tehty, siitä päivästä, jona asia tuli hänen tietoonsa. Euroopan oikeusasiamiehelle tehty kantelu ei vaikuta määräaikaan, eikä sen vuoksi muutoksenhaulle määrätä uutta määräaikaa."@fi,
+    "Dans les 2 mois à compter de la notification au requérant ou, à défaut, du jour où celui-ci en a eu connaissance. L'introduction d'une plainte auprès du Médiateur européen n'a pour effet ni la suspension de ce délai, ni l'ouverture d'un nouveau délai de recours."@fr,
+    "Laistigh de 2 mhí ón bhfógra chuig an ngearánaí, nó dá éagmais sin, ón lá a tháinig sé chun feasa an ghearánaí. Ní chuirfear an tréimhse sin ar fionraí ná ní thosófar tréimhse nua le haghaidh achomharc a dhéanamh mar thoradh ar ghearán a dhéantar leis an Ombudsman Eorpach."@ga,
+    "U roku od 2 mjeseca od slanja obavijesti podnositelju žalbe, a u slučaju izostanka obavijesti, od datuma primanja na znanje okolnosti koje su povod žalbi. Podnošenjem pritužbe Europskom ombudsmanu to se razdoblje ne obustavlja niti se ne otvara novo razdoblje za podnošenje žalbi."@hr,
+    "A vesztes fél értesítésétől, illetve – ennek hiányában – az eredmény ismertté válásától számított 2 hónapon belül. Az európai ombudsmanhoz benyújtott panasz nem eredményezi sem ezen időszak felfüggesztését, sem új fellebbezési időszak megnyílását."@hu,
+    "Entro 2 mesi dalla notifica al ricorrente o, in assenza, dal giorno in cui ne è venuto a conoscenza. La denuncia al Mediatore europeo non produce né l'effetto di sospendere tale periodo, né di aprirne uno nuovo per la presentazione di ricorsi."@it,
+    "Per 2 mėnesius po to, kai apie tai pranešta ieškovui, arba, jei pranešimas neparengiamas, nuo dienos, kai informacija tampa žinoma. Dėl Europos ombudsmenui pateikto skundo šis laikotarpis nebus sustabdytas ar inicijuotas naujas apeliacijų teikimo laikotarpis."@lt,
+    "2 mēnešu laikā no prasītāja informēšanas vai, ja tā nav notikusi, no dienas, kad prasītājs to uzzinājis. Sūdzības iesniegšana Eiropas Ombudam nevar ne atlikt šo periodu, ne arī atklāt jaunu periodu pārsūdzību iesniegšanai."@lv,
+    "Fi żmien xahrejn (2) mill-avviż li jintbagħat lil min qiegħed iressaq l-ilment, jew, fin-nuqqas ta' dan, mill-jum li fih min qiegħed iressaq l-ilment isir jaf b'dan. It-tressiq ta' lment quddiem l-Ombudsman Ewropew mhux se jkollu effett biex jew jissospendi dan il-perijodu jew biex jinfetaħ perijodu ġdid għat-tressiq tal-appelli."@mt,
+    "Binnen 2 maanden na de kennisgeving aan de klager of, bij ontbreken daarvan, binnen 2 maanden na de dag waarop het de klager bekend werd. Een klacht bij de Europese Ombudsman leidt niet tot een opschorting van die periode, noch tot de opening van een nieuwe periode voor het instellen van een beroep."@nl,
+    "W ciągu 2 miesięcy od zawiadomienia strony skarżącej lub, w przypadku braku zawiadomienia, od dnia podania do wiadomości. Wniesienie skargi do Europejskiego Rzecznika Praw Obywatelskich nie skutkuje zawieszeniem ani rozpoczęciem na nowo biegu terminu składania odwołań."@pl,
+    "Num prazo de 2 meses a contar da data de notificação ao requerente ou, na sua falta, a contar do dia em que o requerente tenha tomado conhecimento do ato. As queixas efetuadas ao Provedor de Justiça Europeu não têm como efeito a suspensão do período em questão, nem a abertura de um novo prazo para a interposição de recursos."@pt,
+    "În termen de 2 luni de la notificarea reclamantului sau, în lipsa acesteia, de la ziua în care acesta a luat cunoștință de actul respectiv. O plângere depusă la Ombudsmanul European nu are drept efect suspendarea acestui termen sau deschiderea unui nou termen pentru utilizarea căilor de atac."@ro,
+    "Do 2 mesiacov od vyrozumenia osoby podávajúcej odvolanie alebo, ak to nie je možné, odo dňa, keď túto skutočnosť zistila. Sťažnosť predložená európskemu ombudsmanovi nebude mať za následok prerušenie tohto obdobia, ani začatie novej lehoty na predloženie odvolaní."@sk,
+    "V 2 mesecih od uradnega obvestila tožniku ali, če tega ni bilo, od dneva, ko je tožnik zanj izvedel. Pritožba Evropskemu varuhu človekovih pravic ne prekine navedenega obdobja niti ne začne novega obdobja za vložitev pritožb."@sl,
+    "Inom 2 månader efter att käranden fick meddelandet eller, om så inte skett, från den dag då käranden fick kännedom om saken. Ett klagomål till Europeiska ombudsmannen leder varken till att denna period avbryts eller till att en ny period för inlämning av ett överklagande inleds."@sv .
 
 epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Reviewer_HaEv2nhsYWgNmx2FoRrNgG a epo:Reviewer;
   epo:contextualisedBy epd:id_55aae64f-88a8-44a5-b2fb-8228e97fe6ee_Lot_LOT-0000;

--- a/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_nego_accel/cn_24_nego_accel.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_nego_accel/cn_24_nego_accel.ttl
@@ -277,7 +277,7 @@ epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Notice a epo:CompetitionNotice, epo:
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Mediator_HaEv2nhsYWgNmx2FoRrNgG, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo,
-    epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+    epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw, epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
   epo:hasESenderDispatchDate "2020-03-30T09:10:40+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -404,12 +404,12 @@ epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8
 
 epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
   epo:definesReviewProcedureInformationProvider epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo;
-  epo:definesReviewer epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+  epo:definesReviewer epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw .
 
 epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
   epo:hasReviewDeadlineInformation "There is no right of appeal in this procurement. If you have a complaint or seek to challenge the outcome, please follow the guidance on procedure contained in the previous section."@en .
 
-epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Reviewer_baYYFs6koZdFUDBjfLzPpw a epo:Reviewer;
   epo:contextualisedBy epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_TouchPoint_TPO-0001;
   epo:playedBy epd:id_d1a2e651-b32f-4606-a5dd-d180bab20be1_Organization_TPO-0001 .

--- a/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_open_accel/cn_24_open_accel.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_24_open_accel/cn_24_open_accel.ttl
@@ -22,7 +22,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_AccessTerm_YWMCGu6i5HBxweh3xaUekn a epo:AccessTerm;
-  epo:definesProcurementProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus .
+  epo:definesProcurementProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42 .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_AccessTerm_naE3mfoLZyth2mWXywVhn6 a epo:AccessTerm;
   epo:hasPublicAccessURL "http://www.carabinieri.it/cittadino/informazioni/gare-appalto/gare-appalto/approvvigionamento-di-212-posti-letto-per-la-scuola-mar.-e-brig.-di-firenze"^^xsd:anyURI;
@@ -277,10 +277,10 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Notice a epo:CompetitionNotice, epo:
   epo:announcesLot epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:announcesProcedure epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Buyer_HGvue6GtAm3yppLpDLnBKD,
-    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Mediator_Ap5f9znq6VYbCx76JYpsGs, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus,
+    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Mediator_Ap5f9znq6VYbCx76JYpsGs, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42,
     epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE,
-    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
+    epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw, epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TenderReceiver_HGvue6GtAm3yppLpDLnBKD;
   epo:hasESenderDispatchDate "2020-04-23T07:06:04+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/competition>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/cn-standard>;
@@ -391,7 +391,7 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Procedure_MnX8qyREnFMNLeS5MJAX9K a e
   dct:title "Procedura aperta accelerata per la fornitura di n. 212 posti letto, ognuno composto da arredi e complementi di arredo, per le esigenze della Scuola marescialli e brigadieri di Firenze"@it;
   adms:identifier epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcedureIdentifier_MnX8qyREnFMNLeS5MJAX9K .
 
-epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_oBahBtUnPsC7aJgntGEdus
+epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ProcurementProcedureInformationProvider_awAJeTbTwyjSCKucPVAp42
   a epo:ProcurementProcedureInformationProvider;
   epo:contextualisedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TouchPoint_TPO-0002;
@@ -414,12 +414,12 @@ epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_V
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewTerm_D9HNqZBE8z3NZfKG6rn3Cq a epo:ReviewTerm;
   epo:definesReviewProcedureInformationProvider epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewProcedureInformationProvider_Vy64yERj6Fjzdbdi8yhfHE;
-  epo:definesReviewer epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA .
+  epo:definesReviewer epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw .
 
 epd:id_c77a5424-249b-499b-a45b-2265edb941bb_ReviewTerm_GejsGJcoxiEimbiEooTo5B a epo:ReviewTerm;
   epo:hasReviewDeadlineInformation "Informazioni dettagliate sui termini di presentazione dei ricorsi:   30 giorni dalla notifica o dall’effettiva conoscenza dell’avvenuta aggiudicazione, per ricorrere al competente Tribunale amministrativo regionale del Lazio, sede di Roma."@it .
 
-epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_jwe5W9zs8YV9By53R4pKKA a epo:Reviewer;
+epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Reviewer_baYYFs6koZdFUDBjfLzPpw a epo:Reviewer;
   epo:contextualisedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_c77a5424-249b-499b-a45b-2265edb941bb_TouchPoint_TPO-0001;
   epo:playedBy epd:id_c77a5424-249b-499b-a45b-2265edb941bb_Organization_TPO-0001 .

--- a/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_25/cn_25.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/output/sdk_examples_cn-1.3/cn_25/cn_25.ttl
@@ -183,7 +183,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000 a epo:Lot;
   dct:title "PV Servicing and Maintenance"@en;
   adms:identifier epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_LotIdentifier_246rmGzZvwFBcxRNZTXjTW .
 
-epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA a epo:Mediator;
+epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw a epo:Mediator;
   epo:contextualisedBy epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000;
   epo:hasContactPointInRole epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_TouchPoint_TPO-0001;
   epo:playedBy epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Organization_TPO-0001 .
@@ -204,7 +204,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Notice a epo:CompetitionNotice, epo:
   epo:announcesLot epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Lot_LOT-0000;
   epo:announcesProcedure epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Buyer_HGvue6GtAm3yppLpDLnBKD,
-    epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA, epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
+    epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw, epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProcedureInformationProvider_HGvue6GtAm3yppLpDLnBKD,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementServiceProvider_f7UuQ7S8iGMkM7gCN4x35m,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ReviewProcedureInformationProvider_8FJLixxtuFpiBEq6VwZNfo,
     epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Reviewer_HaEv2nhsYWgNmx2FoRrNgG;
@@ -284,7 +284,7 @@ epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcedurePurpose_eySzap22e3jkZr3f7VX
 
 epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcedureTerm_YWMCGu6i5HBxweh3xaUekn a
     epo:ProcedureTerm;
-  epo:definesMediator epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_jwe5W9zs8YV9By53R4pKKA .
+  epo:definesMediator epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Mediator_baYYFs6koZdFUDBjfLzPpw .
 
 epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_Procedure_MnX8qyREnFMNLeS5MJAX9K a epo:Procedure;
   epo:foreseesContractSpecificTerm epd:id_39d68def-a6aa-4e85-aa8d-97f0600ea41e_ProcurementProjectContractTerm_QmFgWdHMQiunuxrdtntYZx,

--- a/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_maximal.xml
+++ b/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_maximal.xml
@@ -996,13 +996,13 @@
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
@@ -1010,13 +1010,13 @@
 				<cbc:EndpointID>http://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1027,7 +1027,7 @@
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
 						<!--OPT-301-->
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -1541,25 +1541,25 @@
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1570,7 +1570,7 @@
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
 						<!--OPT-301-->
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>

--- a/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_multilingual.xml
+++ b/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_multilingual.xml
@@ -856,7 +856,30 @@
 			</cac:TenderValidityPeriod>
 			<cac:AppealTerms>
 				<cac:PresentationPeriod>
-					<cbc:Description>Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals.</cbc:Description>
+					<cbc:Description languageID="BUL">В рамките на 2 месеца от получаването на известието от ищеца или, в случай че такова липсва, от деня, в който е станало известно на ищеца. Жалба до Европейския омбудсман нито спира този срок, нито води до откриване на нов срок за подаване на жалби.</cbc:Description>
+					<cbc:Description languageID="CES">Ve lhůtě 2 měsíců od oznámení žalobci nebo, není-li k dispozici, ode dne, kdy vstoupilo ve známost žalobce. Stížnost podaná evropskému veřejnému ochránci práv nebude mít za následek ani pozastavení této lhůty, ani započetí nové lhůty pro podání odvolání.</cbc:Description>
+					<cbc:Description languageID="DAN">Senest 2 måneder efter meddelelse af klageren eller, i mangel heraf, efter den dag, klageren har taget sagen til efterretning. En klage til Den Europæiske Ombudsmand bevirker ikke, at denne periode afbrydes, eller at der påbegyndes en ny periode for indgivelse af klager.</cbc:Description>
+					<cbc:Description languageID="DEU">Binnen 2 Monaten ab Mitteilung an den Kläger oder, in Ermangelung dessen, vom Zeitpunkt der Kenntnisnahme durch den Kläger an. Eine Beschwerde beim Europäischen Bürgerbeauftragten bewirkt weder die Unterbrechung dieses Zeitraums noch den Beginn eines neuen Zeitraums für die Einlegung von Rechtsbehelfen.</cbc:Description>
+					<cbc:Description languageID="ELL">Εντός 2 μηνών από την κοινοποίηση στον προσφεύγοντα ή, ελλείψει τέτοιας, από την ημέρα που ο ίδιος έλαβε γνώση. Οι καταγγελίες στον Ευρωπαίο Διαμεσολαβητή δεν έχουν ως αποτέλεσμα ούτε την αναστολή της εν λόγω προθεσμίας ούτε την έναρξη νέας προθεσμίας υποβολής προσφυγών.</cbc:Description>
+					<cbc:Description languageID="ENG">Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals.</cbc:Description>
+					<cbc:Description languageID="EST">2 kuu jooksul hageja teavitamisest, või kui teavitamist ei toimu, 2 kuu jooksul päevast, mil hageja asjast teada sai. Kaebuse esitamine Euroopa Ombudsmanile ei too kaasa apellatsioonide esitamise tähtaja peatamist ega uue tähtaja määramist.</cbc:Description>
+					<cbc:Description languageID="FIN">Muutosta on haettava 2 kuukauden kuluessa ilmoituksesta asianosaiselle tai, jos ilmoitusta ei ole tehty, siitä päivästä, jona asia tuli hänen tietoonsa. Euroopan oikeusasiamiehelle tehty kantelu ei vaikuta määräaikaan, eikä sen vuoksi muutoksenhaulle määrätä uutta määräaikaa.</cbc:Description>
+					<cbc:Description languageID="FRA">Dans les 2 mois à compter de la notification au requérant ou, à défaut, du jour où celui-ci en a eu connaissance. L'introduction d'une plainte auprès du Médiateur européen n'a pour effet ni la suspension de ce délai, ni l'ouverture d'un nouveau délai de recours.</cbc:Description>
+					<cbc:Description languageID="GLE">Laistigh de 2 mhí ón bhfógra chuig an ngearánaí, nó dá éagmais sin, ón lá a tháinig sé chun feasa an ghearánaí. Ní chuirfear an tréimhse sin ar fionraí ná ní thosófar tréimhse nua le haghaidh achomharc a dhéanamh mar thoradh ar ghearán a dhéantar leis an Ombudsman Eorpach.</cbc:Description>
+					<cbc:Description languageID="HRV">U roku od 2 mjeseca od slanja obavijesti podnositelju žalbe, a u slučaju izostanka obavijesti, od datuma primanja na znanje okolnosti koje su povod žalbi. Podnošenjem pritužbe Europskom ombudsmanu to se razdoblje ne obustavlja niti se ne otvara novo razdoblje za podnošenje žalbi.</cbc:Description>
+					<cbc:Description languageID="HUN">A vesztes fél értesítésétől, illetve – ennek hiányában – az eredmény ismertté válásától számított 2 hónapon belül. Az európai ombudsmanhoz benyújtott panasz nem eredményezi sem ezen időszak felfüggesztését, sem új fellebbezési időszak megnyílását.</cbc:Description>
+					<cbc:Description languageID="ITA">Entro 2 mesi dalla notifica al ricorrente o, in assenza, dal giorno in cui ne è venuto a conoscenza. La denuncia al Mediatore europeo non produce né l'effetto di sospendere tale periodo, né di aprirne uno nuovo per la presentazione di ricorsi.</cbc:Description>
+					<cbc:Description languageID="LAV">2 mēnešu laikā no prasītāja informēšanas vai, ja tā nav notikusi, no dienas, kad prasītājs to uzzinājis. Sūdzības iesniegšana Eiropas Ombudam nevar ne atlikt šo periodu, ne arī atklāt jaunu periodu pārsūdzību iesniegšanai.</cbc:Description>
+					<cbc:Description languageID="LIT">Per 2 mėnesius po to, kai apie tai pranešta ieškovui, arba, jei pranešimas neparengiamas, nuo dienos, kai informacija tampa žinoma. Dėl Europos ombudsmenui pateikto skundo šis laikotarpis nebus sustabdytas ar inicijuotas naujas apeliacijų teikimo laikotarpis.</cbc:Description>
+					<cbc:Description languageID="MLT">Fi żmien xahrejn (2) mill-avviż li jintbagħat lil min qiegħed iressaq l-ilment, jew, fin-nuqqas ta' dan, mill-jum li fih min qiegħed iressaq l-ilment isir jaf b'dan. It-tressiq ta' lment quddiem l-Ombudsman Ewropew mhux se jkollu effett biex jew jissospendi dan il-perijodu jew biex jinfetaħ perijodu ġdid għat-tressiq tal-appelli.</cbc:Description>
+					<cbc:Description languageID="NLD">Binnen 2 maanden na de kennisgeving aan de klager of, bij ontbreken daarvan, binnen 2 maanden na de dag waarop het de klager bekend werd. Een klacht bij de Europese Ombudsman leidt niet tot een opschorting van die periode, noch tot de opening van een nieuwe periode voor het instellen van een beroep.</cbc:Description>
+					<cbc:Description languageID="POL">W ciągu 2 miesięcy od zawiadomienia strony skarżącej lub, w przypadku braku zawiadomienia, od dnia podania do wiadomości. Wniesienie skargi do Europejskiego Rzecznika Praw Obywatelskich nie skutkuje zawieszeniem ani rozpoczęciem na nowo biegu terminu składania odwołań.</cbc:Description>
+					<cbc:Description languageID="POR">Num prazo de 2 meses a contar da data de notificação ao requerente ou, na sua falta, a contar do dia em que o requerente tenha tomado conhecimento do ato. As queixas efetuadas ao Provedor de Justiça Europeu não têm como efeito a suspensão do período em questão, nem a abertura de um novo prazo para a interposição de recursos.</cbc:Description>
+					<cbc:Description languageID="RON">În termen de 2 luni de la notificarea reclamantului sau, în lipsa acesteia, de la ziua în care acesta a luat cunoștință de actul respectiv. O plângere depusă la Ombudsmanul European nu are drept efect suspendarea acestui termen sau deschiderea unui nou termen pentru utilizarea căilor de atac.</cbc:Description>
+					<cbc:Description languageID="SLK">Do 2 mesiacov od vyrozumenia osoby podávajúcej odvolanie alebo, ak to nie je možné, odo dňa, keď túto skutočnosť zistila. Sťažnosť predložená európskemu ombudsmanovi nebude mať za následok prerušenie tohto obdobia, ani začatie novej lehoty na predloženie odvolaní.</cbc:Description>
+					<cbc:Description languageID="SLV">V 2 mesecih od uradnega obvestila tožniku ali, če tega ni bilo, od dneva, ko je tožnik zanj izvedel. Pritožba Evropskemu varuhu človekovih pravic ne prekine navedenega obdobja niti ne začne novega obdobja za vložitev pritožb.</cbc:Description>
+					<cbc:Description languageID="SPA">En un plazo de 2 meses a partir de la notificación al recurrente o, en su defecto, del día en que este haya tenido conocimiento del acto en cuestión. Una reclamación ante el Defensor del Pueblo Europeo no tendrá como efecto la suspensión de dicho plazo ni la apertura de un nuevo plazo de presentación de recursos.</cbc:Description>
+					<cbc:Description languageID="SWE">Inom 2 månader efter att käranden fick meddelandet eller, om så inte skett, från den dag då käranden fick kännedom om saken. Ett klagomål till Europeiska ombudsmannen leder varken till att denna period avbryts eller till att en ny period för inlämning av ett överklagande inleds.</cbc:Description>
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
@@ -995,7 +1018,30 @@
 				<cbc:Description languageID="SPA">Véanse los documentos de contratación.</cbc:Description>
 				<cbc:Description languageID="SWE">Enligt vad som anges i upphandlingsdokumenten.</cbc:Description>
 				<cac:OccurenceLocation>
-					<cbc:Description>Premises of the Publications Office in LUXEMBOURG.</cbc:Description>
+					<cbc:Description languageID="BUL">Помещенията на Службата за публикации в Люксембург.</cbc:Description>
+					<cbc:Description languageID="CES">Prostory Úřadu pro publikace v Lucemburku.</cbc:Description>
+					<cbc:Description languageID="DAN">Publikationskontorets lokaler i Luxembourg.</cbc:Description>
+					<cbc:Description languageID="DEU">Räumlichkeiten des Amtes für Veröffentlichungen in Luxemburg.</cbc:Description>
+					<cbc:Description languageID="ELL">Στις εγκαταστάσεις της Υπηρεσίας Εκδόσεων στο Λουξεμβούργο.</cbc:Description>
+					<cbc:Description languageID="ENG">Premises of the Publications Office in LUXEMBOURG.</cbc:Description>
+					<cbc:Description languageID="EST">Väljaannete talituse ruumid Luxembourgis.</cbc:Description>
+					<cbc:Description languageID="FIN">julkaisutoimiston toimitilat Luxemburgissa.</cbc:Description>
+					<cbc:Description languageID="FRA">Locaux de l'Office des publications à Luxembourg.</cbc:Description>
+					<cbc:Description languageID="GLE">Áitreabh Oifig na bhFoilseachán i Lucsamburg.</cbc:Description>
+					<cbc:Description languageID="HRV">Prostori Ureda za publikacije u Luxembourgu.</cbc:Description>
+					<cbc:Description languageID="HUN">A Kiadóhivatal luxembourgi helyiségei.</cbc:Description>
+					<cbc:Description languageID="ITA">Locali dell'Ufficio delle pubblicazioni a Lussemburgo.</cbc:Description>
+					<cbc:Description languageID="LAV">Publikāciju biroja telpas Luksemburgā</cbc:Description>
+					<cbc:Description languageID="LIT">Leidinių biuro patalpos Liuksemburge.</cbc:Description>
+					<cbc:Description languageID="MLT">Il-bini tal-Uffiċċju tal-Pubblikazzjonijiet fil-Lussemburgu.</cbc:Description>
+					<cbc:Description languageID="NLD">de kantoren van het Bureau voor publicaties in Luxemburg.</cbc:Description>
+					<cbc:Description languageID="POL">siedziba Urzędu Publikacji w Luksemburgu.</cbc:Description>
+					<cbc:Description languageID="POR">Instalações do Serviço das Publicações em Luxemburgo.</cbc:Description>
+					<cbc:Description languageID="RON">Sediul Oficiului pentru Publicații din Luxemburg.</cbc:Description>
+					<cbc:Description languageID="SLK">Priestory Úradu pre vydávanie publikácií Európskej únie v Luxemburgu.</cbc:Description>
+					<cbc:Description languageID="SLV">prostori Urada za publikacije v Luxembourgu.</cbc:Description>
+					<cbc:Description languageID="SPA">Instalaciones de la Oficina de Publicaciones en Luxemburgo.</cbc:Description>
+					<cbc:Description languageID="SWE">Publikationsbyråns lokaler i Luxemburg.</cbc:Description>
 				</cac:OccurenceLocation>
 			</cac:OpenTenderEvent>
 			<cac:AuctionTerms>

--- a/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_nego_accel.xml
+++ b/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_nego_accel.xml
@@ -44,7 +44,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>https://www.gov.uk/government/organisations/land-registry</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ENG">Procurement Department</cbc:Name>
@@ -329,7 +329,7 @@
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>

--- a/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_open_accel.xml
+++ b/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_24_open_accel.xml
@@ -40,7 +40,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>http://www.carabinieri.it/Internet/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ITA">Ufficio Approvvigionamenti</cbc:Name>
@@ -63,7 +63,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>http://www.carabinieri.it/Internet/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ITA">Direzione di Commissariato</cbc:Name>
@@ -349,7 +349,7 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:TenderRecipientParty>
@@ -372,7 +372,7 @@
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>

--- a/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_25.xml
+++ b/mappings/package_eforms_sdk1.3_epo4.0/test_data/sdk_examples_cn-1.3/cn_25.xml
@@ -42,7 +42,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>https://www.scottishwater.co.uk/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ENG">Procurement Team</cbc:Name>
@@ -286,7 +286,7 @@
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:MediationParty>
 			</cac:AppealTerms>

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.3.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.3.rml.ttl
@@ -40,7 +40,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.3" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
@@ -124,7 +124,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.7" ;
-            rml:reference "if((exists(@languageID)) and (exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission'))) then . else null" ;
+            rml:reference "if(exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.5_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "c493db6350cd14148afeea8b5edaea31746ad52360ad2ce07cf7d3562f5cdf69"
+    "mapping_suite_hash_digest": "652fcc00e752bf5cf296a228e330adf3ab0ae70e57dda394a6c5800227fb6011"
 }

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
@@ -124,7 +124,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.7" ;
-            rml:reference "if((exists(@languageID)) and (exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission'))) then . else null" ;
+            rml:reference "if(exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.6_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "2185ab2fe4429dfa976cb07d2af9da5f6e77487ca101f9f3d8c1d313206f62cd"
+    "mapping_suite_hash_digest": "4f479aa57568da70ec57bfe4747839e82659747fd697a0e2b035b8ba99aa9d29"
 }

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
@@ -124,7 +124,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.7" ;
-            rml:reference "if((exists(@languageID)) and (exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission'))) then . else null" ;
+            rml:reference "if(exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.7_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "1b7c8100a80df85c0d1dd6e95e00dfed6263047b2a0460a62293b9df20f4c064"
+    "mapping_suite_hash_digest": "f4458b7cb9bf68bbe8aea00531eb0ad981ea6d96b759bd32cd68dc3b7334843a"
 }

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.7.rml.ttl
@@ -124,7 +124,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.7" ;
-            rml:reference "if((exists(@languageID)) and (exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission'))) then . else null" ;
+            rml:reference "if(exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.8_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "baf7aed07b689d7dda7e3d7bd5678a4071b484830203f98d4606e5f11b37fa41"
+    "mapping_suite_hash_digest": "21cce5c630e7232f48dee37025cefb2ba11fbd62f80a5dfc0e688de7191ccbf6"
 }

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.8" ;
             tedm:maxSDKVersion "1.11" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.9_epo4.0/metadata.json
@@ -62,5 +62,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "b5af988ac307307bb123fa9279dc03d062842089d679559487eb199a89f26be7"
+    "mapping_suite_hash_digest": "5f67d4e807cdac35d7f55cb9cf86f3f06da646eae4db9ad12a93b9aca6a55611"
 }

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ContactPoint.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Contract-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot_v1.8-1.11.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.8" ;
             tedm:maxSDKVersion "1.11" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Organization.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-compl.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/Contract-can.rml.ttl
+++ b/src/mappings-can/Contract-can.rml.ttl
@@ -615,7 +615,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Contract_ND-ContractEUFunds a rr:
         tedm:minSDKVersion "1.9.1" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -652,7 +652,7 @@ tedm:MG-langString-title-Contract_ND-SettledContract a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/ContractModificationInformation.rml.ttl
+++ b/src/mappings-can/ContractModificationInformation.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationReasonDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -139,7 +139,7 @@ tedm:MG-langString-hasModificationReasonDescription-ContractModificationInformat
     rr:predicateObjectMap [
         rr:predicate  epo:hasModificationDescription ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/Lot-compl.rml.ttl
+++ b/src/mappings-can/Lot-compl.rml.ttl
@@ -86,7 +86,7 @@ tedm:MG-langString-hasExceedingDurationJustification-ContractTerm_ND-LotDuration
     rr:predicateObjectMap [
         rr:predicate   epo:hasExceedingDurationJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/Procedure-can.rml.ttl
+++ b/src/mappings-can/Procedure-can.rml.ttl
@@ -201,7 +201,7 @@ tedm:MG-langString-hasJustification-DirectAwardTerm-isSubjectToProcedureSpecific
     rr:predicateObjectMap [
         rr:predicate epo-not:hasJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and  (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']) and ./text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/ReviewObject-can.rml.ttl
+++ b/src/mappings-can/ReviewObject-can.rml.ttl
@@ -465,7 +465,7 @@ tedm:MG-langString-description-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -504,7 +504,7 @@ tedm:MG-langString-description-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -543,7 +543,7 @@ tedm:MG-langString-title-ReviewDecision_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -583,7 +583,7 @@ tedm:MG-langString-title-ReviewRequest_ND-ReviewStatus a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate   dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [
@@ -915,7 +915,7 @@ tedm:MG-langString-hasWithdrawalReason-ReviewRequest_ND-ReviewStatus a rr:Triple
     rr:predicateObjectMap [
         rr:predicate   epo:hasWithdrawalReason ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-can/Tender-can.rml.ttl
+++ b/src/mappings-can/Tender-can.rml.ttl
@@ -696,7 +696,7 @@ tedm:MG-langString-hasCalculationMethod-ConcessionEstimate-foreseesConcession-Te
             rr:predicate epo:hasCalculationMethod ;
             rr:objectMap
                 [
-                    rml:reference "if((exists(@languageID)) and (not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' ))) then . else null" ;
+                    rml:reference "if(not( exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']) and efbc:ValueDescription/text() = 'unpublished' )) then . else null" ;
                     rml:languageMap [
                         fnml:functionValue [
                             rr:predicateObjectMap [

--- a/src/mappings-can/Tender-compl.rml.ttl
+++ b/src/mappings-can/Tender-compl.rml.ttl
@@ -198,7 +198,7 @@ tedm:MG-langString-hasPaymentValueDiscrepancyJustification-ContractLotCompletion
     rr:predicateObjectMap [
         rr:predicate   epo:hasPaymentValueDiscrepancyJustification  ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                     fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-pin/PlannedProcurementPart-pin.rml.ttl
+++ b/src/mappings-pin/PlannedProcurementPart-pin.rml.ttl
@@ -327,7 +327,7 @@ tedm:MG-langString-title-PlannedProcurementPart_ND-PartProcurementScope a rr:Tri
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -365,7 +365,7 @@ tedm:MG-langString-description-PlannedProcurementPart_ND-PartProcurementScope a 
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -897,7 +897,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo:hasPlaceOfPerformanceAdditionalInformation  ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -1126,7 +1126,7 @@ tedm:MG-langString-hasAdditionalInformation-ProcurementObject-foreseesProcuremen
     rr:objectMap [
      rdfs:comment "Language of Additional Information of MG-ProcurementObject under ND-PartProcurementScope" ;
      rdfs:label "BT-300-Part-Language" ;
-     rml:reference "if(exists(@languageID)) then . else null" ;
+     rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.11-1.11.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.11-1.11.rml.ttl
@@ -68,7 +68,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.12+.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.12+.rml.ttl
@@ -88,7 +88,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -161,7 +161,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:predicate epo-not:hasLateSubmissionInformationDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.12" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.3-1.10.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.3-1.10.rml.ttl
@@ -69,7 +69,7 @@ tedm:MG-langString-hasNonElectronicSubmissionDescription-SubmissionTerm-isSubjec
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonElectronicSubmissionDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.3-1.3.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.3-1.3.rml.ttl
@@ -40,7 +40,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.3" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.3-1.7.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.3-1.7.rml.ttl
@@ -124,7 +124,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.3" ;
             tedm:maxSDKVersion "1.7" ;
-            rml:reference "if((exists(@languageID)) and (exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission'))) then . else null" ;
+            rml:reference "if(exists(../cbc:TendererRequirementTypeCode/@listName='missing-info-submission')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.4+.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.4+.rml.ttl
@@ -39,7 +39,7 @@ tedm:MG-langString-hasGuaranteeDescription-SubmissionTerm-isSubjectToLotSpecific
     rr:predicate epo-not:hasGuaranteeDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings-versioned/Lot_v1.8-1.11.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.8-1.11.rml.ttl
@@ -101,7 +101,7 @@ tedm:MG-langString-hasLateSubmissionInformationDescription-SubmissionTerm-isSubj
         rr:objectMap [
             tedm:minSDKVersion "1.8" ;
             tedm:maxSDKVersion "1.11" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-versioned/Tender-can_v1.3-1.8.rml.ttl
+++ b/src/mappings-versioned/Tender-can_v1.3-1.8.rml.ttl
@@ -140,7 +140,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:maxSDKVersion "1.8" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings-versioned/Tender-can_v1.9+.rml.ttl
+++ b/src/mappings-versioned/Tender-can_v1.9+.rml.ttl
@@ -135,7 +135,7 @@ tedm:MG-langString-description-SubcontractingEstimate-foreseesSubcontracting-Ten
         tedm:minSDKVersion "1.9" ;
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(../efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings/ChangeInformation.rml.ttl
+++ b/src/mappings/ChangeInformation.rml.ttl
@@ -256,7 +256,7 @@ tedm:MG-langString-hasChangeDescription-ChangeInformation_ND-Change a rr:Triples
   rr:predicateObjectMap [
     rr:predicate epo-not:hasChangeDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -294,7 +294,7 @@ tedm:MG-langString-hasChangeReasonDescription-ChangeInformation_ND-ChangeReason 
     rr:predicate epo-not:hasChangeReasonDescription ;
     rr:objectMap [
       tedm:minSDKVersion "1.4" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings/ContactPoint.rml.ttl
+++ b/src/mappings/ContactPoint.rml.ttl
@@ -264,7 +264,7 @@ tedm:MG-langString-description-ContactPoint_ND-Touchpoint a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -4747,7 +4747,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-Lot_
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4784,7 +4784,7 @@ tedm:MG-langString-description-EAuctionTechnique-usesTechnique-Lot_ND-AuctionTer
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4821,7 +4821,7 @@ tedm:MG-langString-description-ExclusionGround-specifiesProcurementCriterion-Lot
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4859,7 +4859,7 @@ tedm:MG-langString-description-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4896,7 +4896,7 @@ tedm:MG-langString-description-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4934,7 +4934,7 @@ tedm:MG-langString-description-NonDisclosureAgreementTerm-isSubjectToLotSpecific
     rr:predicate dct:description ;
     rr:objectMap [
       tedm:minSDKVersion "1.5.12" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -4971,7 +4971,7 @@ tedm:MG-langString-description-SecurityClearanceTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5008,7 +5008,7 @@ tedm:MG-langString-description-SelectionCriterion-specifiesProcurementCriterion-
   rr:predicateObjectMap [
     rr:predicate dct:description ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5045,7 +5045,7 @@ tedm:MG-langString-fullAddress-Address-definesOpeningPlace-OpeningTerm-isSubject
   rr:predicateObjectMap [
     rr:predicate locn:fullAddress ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5082,7 +5082,7 @@ tedm:MG-langString-hasAdditionalInformation-Lot_ND-LotProcurementScope a rr:Trip
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5119,7 +5119,7 @@ tedm:MG-langString-hasAwardCriteriaEvaluationFormula-AwardEvaluationTerm-isSubje
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaEvaluationFormula ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5156,7 +5156,7 @@ tedm:MG-langString-hasAwardCriteriaOrderJustification-AwardEvaluationTerm-isSubj
   rr:predicateObjectMap [
     rr:predicate epo-not:hasAwardCriteriaOrderJustification ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5193,7 +5193,7 @@ tedm:MG-langString-hasBuyerCategoryDescription-FrameworkAgreementTerm-isSubjectT
   rr:predicateObjectMap [
     rr:predicate epo-not:hasBuyerCategoryDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5230,7 +5230,7 @@ tedm:MG-langString-hasDurationExtensionJustification-FrameworkAgreementTerm-isSu
   rr:predicateObjectMap [
     rr:predicate epo-not:hasDurationExtensionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5267,7 +5267,7 @@ tedm:MG-langString-hasLegalFormRequirement-ContractTerm-foreseesContractSpecific
   rr:predicateObjectMap [
     rr:predicate epo-not:hasLegalFormRequirement ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and  (../cbc:CompanyLegalFormCode[@listName='required' and text()='true'])) then . else null" ;
+      rml:reference "if(../cbc:CompanyLegalFormCode[@listName='required' and text()='true']) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5304,7 +5304,7 @@ tedm:MG-langString-hasNonAccessibilityCriterionJustification-StrategicProcuremen
   rr:predicateObjectMap [
     rr:predicate epo-not:hasNonAccessibilityCriterionJustification ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5341,7 +5341,7 @@ tedm:MG-langString-hasOpeningDescription-OpeningTerm-isSubjectToLotSpecificTerm-
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOpeningDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5378,7 +5378,7 @@ tedm:MG-langString-hasOptionsDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasOptionsDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5415,7 +5415,7 @@ tedm:MG-langString-hasPaymentArrangement-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPaymentArrangement ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5453,7 +5453,7 @@ tedm:MG-langString-hasPerformanceConditions-ContractTerm-foreseesContractSpecifi
     rr:predicate epo-not:hasPerformanceConditions ;
     rr:objectMap [
       tedm:minSDKVersion "1.9.1" ;
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5490,7 +5490,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5527,7 +5527,7 @@ tedm:MG-langString-hasRecurrenceDescription-Lot_ND-LotTenderingTerms a rr:Triple
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRecurrenceDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5564,7 +5564,7 @@ tedm:MG-langString-hasRenewalDescription-ContractTerm-foreseesContractSpecificTe
   rr:predicateObjectMap [
     rr:predicate epo-not:hasRenewalDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5601,7 +5601,7 @@ tedm:MG-langString-hasReviewDeadlineInformation-ReviewTerm-isSubjectToLotSpecifi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasReviewDeadlineInformation ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5638,7 +5638,7 @@ tedm:MG-langString-hasStrategicProcurementDescription-StrategicProcurement-fulfi
   rr:predicateObjectMap [
     rr:predicate epo-not:hasStrategicProcurementDescription ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5675,7 +5675,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-Lot_ND
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+      rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5712,7 +5712,7 @@ tedm:MG-langString-prefLabel-SelectionCriterion-specifiesProcurementCriterion-Lo
   rr:predicateObjectMap [
     rr:predicate skos:prefLabel ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [
@@ -5749,7 +5749,7 @@ tedm:MG-langString-title-Lot_ND-LotProcurementScope a rr:TriplesMap ;
   rr:predicateObjectMap [
     rr:predicate dct:title ;
     rr:objectMap [
-      rml:reference "if(exists(@languageID)) then . else null" ;
+      rml:reference "." ;
       rml:languageMap [
         fnml:functionValue [
           rr:predicateObjectMap [

--- a/src/mappings/LotGroup.rml.ttl
+++ b/src/mappings/LotGroup.rml.ttl
@@ -647,7 +647,7 @@ tedm:MG-langString-description-AwardCriterion-specifiesProcurementCriterion-LotG
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -684,7 +684,7 @@ tedm:MG-langString-description-LotGroup_ND-LotsGroupProcurementScope a rr:Triple
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -721,7 +721,7 @@ tedm:MG-langString-prefLabel-AwardCriterion-specifiesProcurementCriterion-LotGro
     rr:predicateObjectMap [
         rr:predicate skos:prefLabel ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -758,7 +758,7 @@ tedm:MG-langString-title-LotGroup_ND-LotsGroupProcurementScope a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings/Organization.rml.ttl
+++ b/src/mappings/Organization.rml.ttl
@@ -338,7 +338,7 @@ tedm:MG-langString-hasLegalName-Organization_ND-Company a rr:TriplesMap ;
     rr:predicateObjectMap [
         rr:predicate epo-not:hasLegalName ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/mappings/Procedure.rml.ttl
+++ b/src/mappings/Procedure.rml.ttl
@@ -1297,7 +1297,7 @@ tedm:MG-langString-description-Procedure_ND-ProcedureProcurementScope a rr:Tripl
     rr:predicateObjectMap [
         rr:predicate dct:description ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1335,7 +1335,7 @@ tedm:MG-langString-hasAcceleratedProcedureJustification-Procedure_ND-Accelerated
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAcceleratedProcedureJustification ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1373,7 +1373,7 @@ tedm:MG-langString-hasAdditionalInformation-Procedure_ND-ProcedureProcurementSco
     rr:predicateObjectMap [
         rr:predicate epo-not:hasAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1411,7 +1411,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished'))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1449,7 +1449,7 @@ tedm:MG-langString-hasLegalBasisDescription-Procedure_ND-LocalLegalBasisNoID a r
         rr:predicate epo-not:hasLegalBasisDescription ;
         rr:objectMap [
             tedm:minSDKVersion "1.4" ;
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1524,7 +1524,7 @@ tedm:MG-langString-hasMainFeature-Procedure_ND-ProcedureTenderingProcess a rr:Tr
     rr:predicateObjectMap [
         rr:predicate epo-not:hasMainFeature ;
         rr:objectMap [
-            rml:reference "if((exists(@languageID)) and (not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' ))) then . else null" ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']) and ./text() = 'unpublished' )) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1561,7 +1561,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
     rr:predicateObjectMap [
         rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [
@@ -1599,7 +1599,7 @@ tedm:MG-langString-title-Procedure_ND-ProcedureProcurementScope a rr:TriplesMap 
     rr:predicateObjectMap [
         rr:predicate dct:title ;
         rr:objectMap [
-            rml:reference "if(exists(@languageID)) then . else null" ;
+            rml:reference "." ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_maximal.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_maximal.xml
@@ -996,13 +996,13 @@
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
@@ -1010,13 +1010,13 @@
 				<cbc:EndpointID>http://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1027,7 +1027,7 @@
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
 						<!--OPT-301-->
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -1541,25 +1541,25 @@
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
 					<!--OPT-301-->
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1570,7 +1570,7 @@
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
 						<!--OPT-301-->
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_maximal_100_lots.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_maximal_100_lots.xml
@@ -639,23 +639,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -664,7 +664,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -1007,23 +1007,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1032,7 +1032,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -1375,23 +1375,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1400,7 +1400,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -1743,23 +1743,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -1768,7 +1768,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -2111,23 +2111,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -2136,7 +2136,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -2479,23 +2479,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -2504,7 +2504,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -2847,23 +2847,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -2872,7 +2872,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -3215,23 +3215,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -3240,7 +3240,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -3583,23 +3583,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -3608,7 +3608,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -3951,23 +3951,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -3976,7 +3976,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -4319,23 +4319,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -4344,7 +4344,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -4687,23 +4687,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -4712,7 +4712,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -5055,23 +5055,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -5080,7 +5080,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -5423,23 +5423,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -5448,7 +5448,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -5791,23 +5791,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -5816,7 +5816,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -6159,23 +6159,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -6184,7 +6184,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -6527,23 +6527,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -6552,7 +6552,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -6895,23 +6895,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -6920,7 +6920,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -7263,23 +7263,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -7288,7 +7288,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -7631,23 +7631,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -7656,7 +7656,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -7999,23 +7999,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -8024,7 +8024,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -8367,23 +8367,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -8392,7 +8392,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -8735,23 +8735,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -8760,7 +8760,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -9103,23 +9103,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -9128,7 +9128,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -9471,23 +9471,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -9496,7 +9496,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -9839,23 +9839,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -9864,7 +9864,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -10207,23 +10207,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -10232,7 +10232,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -10575,23 +10575,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -10600,7 +10600,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -10943,23 +10943,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -10968,7 +10968,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -11311,23 +11311,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -11336,7 +11336,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -11679,23 +11679,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -11704,7 +11704,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -12047,23 +12047,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -12072,7 +12072,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -12415,23 +12415,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -12440,7 +12440,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -12783,23 +12783,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -12808,7 +12808,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -13151,23 +13151,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -13176,7 +13176,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -13519,23 +13519,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -13544,7 +13544,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -13887,23 +13887,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -13912,7 +13912,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -14255,23 +14255,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -14280,7 +14280,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -14623,23 +14623,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -14648,7 +14648,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -14991,23 +14991,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -15016,7 +15016,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -15359,23 +15359,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -15384,7 +15384,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -15727,23 +15727,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -15752,7 +15752,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -16095,23 +16095,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -16120,7 +16120,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -16463,23 +16463,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -16488,7 +16488,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -16831,23 +16831,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -16856,7 +16856,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -17199,23 +17199,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -17224,7 +17224,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -17567,23 +17567,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -17592,7 +17592,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -17935,23 +17935,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -17960,7 +17960,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -18303,23 +18303,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -18328,7 +18328,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -18671,23 +18671,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -18696,7 +18696,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -19039,23 +19039,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -19064,7 +19064,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -19407,23 +19407,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -19432,7 +19432,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -19775,23 +19775,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -19800,7 +19800,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -20143,23 +20143,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -20168,7 +20168,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -20511,23 +20511,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -20536,7 +20536,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -20879,23 +20879,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -20904,7 +20904,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -21247,23 +21247,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -21272,7 +21272,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -21615,23 +21615,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -21640,7 +21640,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -21983,23 +21983,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -22008,7 +22008,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -22351,23 +22351,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -22376,7 +22376,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -22719,23 +22719,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -22744,7 +22744,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -23087,23 +23087,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -23112,7 +23112,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -23455,23 +23455,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -23480,7 +23480,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -23823,23 +23823,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -23848,7 +23848,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -24191,23 +24191,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -24216,7 +24216,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -24559,23 +24559,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -24584,7 +24584,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -24927,23 +24927,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -24952,7 +24952,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -25295,23 +25295,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -25320,7 +25320,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -25663,23 +25663,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -25688,7 +25688,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -26031,23 +26031,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -26056,7 +26056,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -26399,23 +26399,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -26424,7 +26424,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -26767,23 +26767,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -26792,7 +26792,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -27135,23 +27135,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -27160,7 +27160,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -27503,23 +27503,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -27528,7 +27528,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -27871,23 +27871,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -27896,7 +27896,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -28239,23 +28239,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -28264,7 +28264,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -28607,23 +28607,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -28632,7 +28632,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -28975,23 +28975,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -29000,7 +29000,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -29343,23 +29343,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -29368,7 +29368,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -29711,23 +29711,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -29736,7 +29736,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -30079,23 +30079,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -30104,7 +30104,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -30447,23 +30447,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -30472,7 +30472,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -30815,23 +30815,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -30840,7 +30840,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -31183,23 +31183,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -31208,7 +31208,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -31551,23 +31551,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -31576,7 +31576,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -31919,23 +31919,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -31944,7 +31944,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -32287,23 +32287,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -32312,7 +32312,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -32655,23 +32655,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -32680,7 +32680,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -33023,23 +33023,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -33048,7 +33048,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -33391,23 +33391,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -33416,7 +33416,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -33759,23 +33759,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -33784,7 +33784,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -34127,23 +34127,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -34152,7 +34152,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -34495,23 +34495,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -34520,7 +34520,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -34863,23 +34863,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -34888,7 +34888,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -35231,23 +35231,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -35256,7 +35256,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -35599,23 +35599,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -35624,7 +35624,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -35967,23 +35967,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -35992,7 +35992,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -36335,23 +36335,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -36360,7 +36360,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -36703,23 +36703,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -36728,7 +36728,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
@@ -37071,23 +37071,23 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:DocumentProviderParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:DocumentProviderParty>
 			<cac:TenderRecipientParty>
 				<cbc:EndpointID>https://tender-submit.fin-adm.com/esubmission</cbc:EndpointID>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderRecipientParty>
 			<cac:TenderEvaluationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0003</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0003</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:TenderEvaluationParty>
 			<cac:AppealTerms>
@@ -37096,7 +37096,7 @@
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_multilingual.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_multilingual.xml
@@ -856,7 +856,30 @@
 			</cac:TenderValidityPeriod>
 			<cac:AppealTerms>
 				<cac:PresentationPeriod>
-					<cbc:Description>Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals.</cbc:Description>
+					<cbc:Description languageID="BUL">В рамките на 2 месеца от получаването на известието от ищеца или, в случай че такова липсва, от деня, в който е станало известно на ищеца. Жалба до Европейския омбудсман нито спира този срок, нито води до откриване на нов срок за подаване на жалби.</cbc:Description>
+					<cbc:Description languageID="CES">Ve lhůtě 2 měsíců od oznámení žalobci nebo, není-li k dispozici, ode dne, kdy vstoupilo ve známost žalobce. Stížnost podaná evropskému veřejnému ochránci práv nebude mít za následek ani pozastavení této lhůty, ani započetí nové lhůty pro podání odvolání.</cbc:Description>
+					<cbc:Description languageID="DAN">Senest 2 måneder efter meddelelse af klageren eller, i mangel heraf, efter den dag, klageren har taget sagen til efterretning. En klage til Den Europæiske Ombudsmand bevirker ikke, at denne periode afbrydes, eller at der påbegyndes en ny periode for indgivelse af klager.</cbc:Description>
+					<cbc:Description languageID="DEU">Binnen 2 Monaten ab Mitteilung an den Kläger oder, in Ermangelung dessen, vom Zeitpunkt der Kenntnisnahme durch den Kläger an. Eine Beschwerde beim Europäischen Bürgerbeauftragten bewirkt weder die Unterbrechung dieses Zeitraums noch den Beginn eines neuen Zeitraums für die Einlegung von Rechtsbehelfen.</cbc:Description>
+					<cbc:Description languageID="ELL">Εντός 2 μηνών από την κοινοποίηση στον προσφεύγοντα ή, ελλείψει τέτοιας, από την ημέρα που ο ίδιος έλαβε γνώση. Οι καταγγελίες στον Ευρωπαίο Διαμεσολαβητή δεν έχουν ως αποτέλεσμα ούτε την αναστολή της εν λόγω προθεσμίας ούτε την έναρξη νέας προθεσμίας υποβολής προσφυγών.</cbc:Description>
+					<cbc:Description languageID="ENG">Within 2 months of the notification to the plaintiff, or, in absence thereof, of the day on which it came to the knowledge of the plaintiff. A complaint to the European Ombudsman does not have as an effect either to suspend this period or to open a new period for lodging appeals.</cbc:Description>
+					<cbc:Description languageID="EST">2 kuu jooksul hageja teavitamisest, või kui teavitamist ei toimu, 2 kuu jooksul päevast, mil hageja asjast teada sai. Kaebuse esitamine Euroopa Ombudsmanile ei too kaasa apellatsioonide esitamise tähtaja peatamist ega uue tähtaja määramist.</cbc:Description>
+					<cbc:Description languageID="FIN">Muutosta on haettava 2 kuukauden kuluessa ilmoituksesta asianosaiselle tai, jos ilmoitusta ei ole tehty, siitä päivästä, jona asia tuli hänen tietoonsa. Euroopan oikeusasiamiehelle tehty kantelu ei vaikuta määräaikaan, eikä sen vuoksi muutoksenhaulle määrätä uutta määräaikaa.</cbc:Description>
+					<cbc:Description languageID="FRA">Dans les 2 mois à compter de la notification au requérant ou, à défaut, du jour où celui-ci en a eu connaissance. L'introduction d'une plainte auprès du Médiateur européen n'a pour effet ni la suspension de ce délai, ni l'ouverture d'un nouveau délai de recours.</cbc:Description>
+					<cbc:Description languageID="GLE">Laistigh de 2 mhí ón bhfógra chuig an ngearánaí, nó dá éagmais sin, ón lá a tháinig sé chun feasa an ghearánaí. Ní chuirfear an tréimhse sin ar fionraí ná ní thosófar tréimhse nua le haghaidh achomharc a dhéanamh mar thoradh ar ghearán a dhéantar leis an Ombudsman Eorpach.</cbc:Description>
+					<cbc:Description languageID="HRV">U roku od 2 mjeseca od slanja obavijesti podnositelju žalbe, a u slučaju izostanka obavijesti, od datuma primanja na znanje okolnosti koje su povod žalbi. Podnošenjem pritužbe Europskom ombudsmanu to se razdoblje ne obustavlja niti se ne otvara novo razdoblje za podnošenje žalbi.</cbc:Description>
+					<cbc:Description languageID="HUN">A vesztes fél értesítésétől, illetve – ennek hiányában – az eredmény ismertté válásától számított 2 hónapon belül. Az európai ombudsmanhoz benyújtott panasz nem eredményezi sem ezen időszak felfüggesztését, sem új fellebbezési időszak megnyílását.</cbc:Description>
+					<cbc:Description languageID="ITA">Entro 2 mesi dalla notifica al ricorrente o, in assenza, dal giorno in cui ne è venuto a conoscenza. La denuncia al Mediatore europeo non produce né l'effetto di sospendere tale periodo, né di aprirne uno nuovo per la presentazione di ricorsi.</cbc:Description>
+					<cbc:Description languageID="LAV">2 mēnešu laikā no prasītāja informēšanas vai, ja tā nav notikusi, no dienas, kad prasītājs to uzzinājis. Sūdzības iesniegšana Eiropas Ombudam nevar ne atlikt šo periodu, ne arī atklāt jaunu periodu pārsūdzību iesniegšanai.</cbc:Description>
+					<cbc:Description languageID="LIT">Per 2 mėnesius po to, kai apie tai pranešta ieškovui, arba, jei pranešimas neparengiamas, nuo dienos, kai informacija tampa žinoma. Dėl Europos ombudsmenui pateikto skundo šis laikotarpis nebus sustabdytas ar inicijuotas naujas apeliacijų teikimo laikotarpis.</cbc:Description>
+					<cbc:Description languageID="MLT">Fi żmien xahrejn (2) mill-avviż li jintbagħat lil min qiegħed iressaq l-ilment, jew, fin-nuqqas ta' dan, mill-jum li fih min qiegħed iressaq l-ilment isir jaf b'dan. It-tressiq ta' lment quddiem l-Ombudsman Ewropew mhux se jkollu effett biex jew jissospendi dan il-perijodu jew biex jinfetaħ perijodu ġdid għat-tressiq tal-appelli.</cbc:Description>
+					<cbc:Description languageID="NLD">Binnen 2 maanden na de kennisgeving aan de klager of, bij ontbreken daarvan, binnen 2 maanden na de dag waarop het de klager bekend werd. Een klacht bij de Europese Ombudsman leidt niet tot een opschorting van die periode, noch tot de opening van een nieuwe periode voor het instellen van een beroep.</cbc:Description>
+					<cbc:Description languageID="POL">W ciągu 2 miesięcy od zawiadomienia strony skarżącej lub, w przypadku braku zawiadomienia, od dnia podania do wiadomości. Wniesienie skargi do Europejskiego Rzecznika Praw Obywatelskich nie skutkuje zawieszeniem ani rozpoczęciem na nowo biegu terminu składania odwołań.</cbc:Description>
+					<cbc:Description languageID="POR">Num prazo de 2 meses a contar da data de notificação ao requerente ou, na sua falta, a contar do dia em que o requerente tenha tomado conhecimento do ato. As queixas efetuadas ao Provedor de Justiça Europeu não têm como efeito a suspensão do período em questão, nem a abertura de um novo prazo para a interposição de recursos.</cbc:Description>
+					<cbc:Description languageID="RON">În termen de 2 luni de la notificarea reclamantului sau, în lipsa acesteia, de la ziua în care acesta a luat cunoștință de actul respectiv. O plângere depusă la Ombudsmanul European nu are drept efect suspendarea acestui termen sau deschiderea unui nou termen pentru utilizarea căilor de atac.</cbc:Description>
+					<cbc:Description languageID="SLK">Do 2 mesiacov od vyrozumenia osoby podávajúcej odvolanie alebo, ak to nie je možné, odo dňa, keď túto skutočnosť zistila. Sťažnosť predložená európskemu ombudsmanovi nebude mať za následok prerušenie tohto obdobia, ani začatie novej lehoty na predloženie odvolaní.</cbc:Description>
+					<cbc:Description languageID="SLV">V 2 mesecih od uradnega obvestila tožniku ali, če tega ni bilo, od dneva, ko je tožnik zanj izvedel. Pritožba Evropskemu varuhu človekovih pravic ne prekine navedenega obdobja niti ne začne novega obdobja za vložitev pritožb.</cbc:Description>
+					<cbc:Description languageID="SPA">En un plazo de 2 meses a partir de la notificación al recurrente o, en su defecto, del día en que este haya tenido conocimiento del acto en cuestión. Una reclamación ante el Defensor del Pueblo Europeo no tendrá como efecto la suspensión de dicho plazo ni la apertura de un nuevo plazo de presentación de recursos.</cbc:Description>
+					<cbc:Description languageID="SWE">Inom 2 månader efter att käranden fick meddelandet eller, om så inte skett, från den dag då käranden fick kännedom om saken. Ett klagomål till Europeiska ombudsmannen leder varken till att denna period avbryts eller till att en ny period för inlämning av ett överklagande inleds.</cbc:Description>
 				</cac:PresentationPeriod>
 				<cac:AppealInformationParty>
 					<cac:PartyIdentification>
@@ -995,7 +1018,30 @@
 				<cbc:Description languageID="SPA">Véanse los documentos de contratación.</cbc:Description>
 				<cbc:Description languageID="SWE">Enligt vad som anges i upphandlingsdokumenten.</cbc:Description>
 				<cac:OccurenceLocation>
-					<cbc:Description>Premises of the Publications Office in LUXEMBOURG.</cbc:Description>
+					<cbc:Description languageID="BUL">Помещенията на Службата за публикации в Люксембург.</cbc:Description>
+					<cbc:Description languageID="CES">Prostory Úřadu pro publikace v Lucemburku.</cbc:Description>
+					<cbc:Description languageID="DAN">Publikationskontorets lokaler i Luxembourg.</cbc:Description>
+					<cbc:Description languageID="DEU">Räumlichkeiten des Amtes für Veröffentlichungen in Luxemburg.</cbc:Description>
+					<cbc:Description languageID="ELL">Στις εγκαταστάσεις της Υπηρεσίας Εκδόσεων στο Λουξεμβούργο.</cbc:Description>
+					<cbc:Description languageID="ENG">Premises of the Publications Office in LUXEMBOURG.</cbc:Description>
+					<cbc:Description languageID="EST">Väljaannete talituse ruumid Luxembourgis.</cbc:Description>
+					<cbc:Description languageID="FIN">julkaisutoimiston toimitilat Luxemburgissa.</cbc:Description>
+					<cbc:Description languageID="FRA">Locaux de l'Office des publications à Luxembourg.</cbc:Description>
+					<cbc:Description languageID="GLE">Áitreabh Oifig na bhFoilseachán i Lucsamburg.</cbc:Description>
+					<cbc:Description languageID="HRV">Prostori Ureda za publikacije u Luxembourgu.</cbc:Description>
+					<cbc:Description languageID="HUN">A Kiadóhivatal luxembourgi helyiségei.</cbc:Description>
+					<cbc:Description languageID="ITA">Locali dell'Ufficio delle pubblicazioni a Lussemburgo.</cbc:Description>
+					<cbc:Description languageID="LAV">Publikāciju biroja telpas Luksemburgā</cbc:Description>
+					<cbc:Description languageID="LIT">Leidinių biuro patalpos Liuksemburge.</cbc:Description>
+					<cbc:Description languageID="MLT">Il-bini tal-Uffiċċju tal-Pubblikazzjonijiet fil-Lussemburgu.</cbc:Description>
+					<cbc:Description languageID="NLD">de kantoren van het Bureau voor publicaties in Luxemburg.</cbc:Description>
+					<cbc:Description languageID="POL">siedziba Urzędu Publikacji w Luksemburgu.</cbc:Description>
+					<cbc:Description languageID="POR">Instalações do Serviço das Publicações em Luxemburgo.</cbc:Description>
+					<cbc:Description languageID="RON">Sediul Oficiului pentru Publicații din Luxemburg.</cbc:Description>
+					<cbc:Description languageID="SLK">Priestory Úradu pre vydávanie publikácií Európskej únie v Luxemburgu.</cbc:Description>
+					<cbc:Description languageID="SLV">prostori Urada za publikacije v Luxembourgu.</cbc:Description>
+					<cbc:Description languageID="SPA">Instalaciones de la Oficina de Publicaciones en Luxemburgo.</cbc:Description>
+					<cbc:Description languageID="SWE">Publikationsbyråns lokaler i Luxemburg.</cbc:Description>
 				</cac:OccurenceLocation>
 			</cac:OpenTenderEvent>
 			<cac:AuctionTerms>

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_nego_accel.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_nego_accel.xml
@@ -44,7 +44,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>https://www.gov.uk/government/organisations/land-registry</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ENG">Procurement Department</cbc:Name>
@@ -329,7 +329,7 @@
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_open_accel.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_24_open_accel.xml
@@ -40,7 +40,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>http://www.carabinieri.it/Internet/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ITA">Ufficio Approvvigionamenti</cbc:Name>
@@ -63,7 +63,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>http://www.carabinieri.it/Internet/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ITA">Direzione di Commissariato</cbc:Name>
@@ -349,7 +349,7 @@
 			</cac:AwardingTerms>
 			<cac:AdditionalInformationParty>
 				<cac:PartyIdentification>
-					<cbc:ID schemeName="touchpoint">TPO-0002</cbc:ID>
+					<cbc:ID schemeName="organization">TPO-0002</cbc:ID>
 				</cac:PartyIdentification>
 			</cac:AdditionalInformationParty>
 			<cac:TenderRecipientParty>
@@ -372,7 +372,7 @@
 				</cac:AppealInformationParty>
 				<cac:AppealReceiverParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>

--- a/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_25.xml
+++ b/test_data/sdk_examples_cn/eforms-sdk-1.3/cn_25.xml
@@ -42,7 +42,7 @@
 							<efac:TouchPoint>
 								<cbc:WebsiteURI>https://www.scottishwater.co.uk/</cbc:WebsiteURI>
 								<cac:PartyIdentification>
-									<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+									<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 								</cac:PartyIdentification>
 								<cac:PartyName>
 									<cbc:Name languageID="ENG">Procurement Team</cbc:Name>
@@ -286,7 +286,7 @@
 				</cac:AppealReceiverParty>
 				<cac:MediationParty>
 					<cac:PartyIdentification>
-						<cbc:ID schemeName="touchpoint">TPO-0001</cbc:ID>
+						<cbc:ID schemeName="organization">TPO-0001</cbc:ID>
 					</cac:PartyIdentification>
 				</cac:MediationParty>
 			</cac:AppealTerms>


### PR DESCRIPTION
commit `ee7a1ba37900141ba30bf79725f5b09aadcba19b` "Update langMap TMaps to prevent RMLMapper errors when lang missing"
- RMLMapper error on any notice with expected but absent language tag/attribute on any element

Reverts also related data update commit which would trigger the error and fail the (v1.3) package. Note that because of this certain information in the RDF outputs will also be restructured (e.g. hashes will appear to change), as the data in the newer patch version was different.