### PR TITLE
[TEDSWS-303] Guard against empty DynamicPurchaseSystemTechnique

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -1451,7 +1451,8 @@ tedm:MG-DynamicPurchaseSystemTechnique-usesTechnique-Lot_ND-LotTenderingProcess 
     rr:subjectMap
         [
             rdfs:label "ND-LotTenderingProcess";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_DynamicPurchaseSystemTechnicalUsage_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # INFO: forbidden in subtypes 1-6, 14-15, 19, 23-24, 28, 32, 35-40, CEI, E1-E2, E6, T01-T02
+            rml:reference "if (exists(cac:ContractingSystem/cbc:ContractingSystemTypeCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_DynamicPurchaseSystemTechnicalUsage_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:DynamicPurchaseSystemTechnique
         ] ;
     rr:predicateObjectMap

--- a/src/output-pmc.ttl
+++ b/src/output-pmc.ttl
@@ -37,9 +37,6 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua 
   epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
-epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_DynamicPurchaseSystemTechnicalUsage_Hu7wzHDygWmeSqTPnwY9wa
-  a epo:DynamicPurchaseSystemTechnique .
-
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Identifier_ORG-0001 a adms:Identifier;
   epo:hasScheme "organization";
   skos:notation "ORG-0001" .
@@ -57,7 +54,6 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Lot_LOT-0001 a epo:Lot;
   epo:hasPurpose epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv;
   epo:isSubjectToLotSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_ACUWmqLfdo5YEi9wsUS9mJ,
     epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_adyhtKZkzxr6SEjy3tRyua;
-  epo:usesTechnique epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_DynamicPurchaseSystemTechnicalUsage_Hu7wzHDygWmeSqTPnwY9wa;
   dct:description "Lot description"@en;
   dct:title "Lot Name"@en;
   adms:identifier epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotIdentifier_adyhtKZkzxr6SEjy3tRyua .

--- a/src/output-versioned/E1_minimal-1.13.ttl
+++ b/src/output-versioned/E1_minimal-1.13.ttl
@@ -37,9 +37,6 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua 
   epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
-epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_DynamicPurchaseSystemTechnicalUsage_Hu7wzHDygWmeSqTPnwY9wa
-  a epo:DynamicPurchaseSystemTechnique .
-
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Identifier_ORG-0001 a adms:Identifier;
   epo:hasScheme "organization";
   skos:notation "ORG-0001" .
@@ -57,7 +54,6 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Lot_LOT-0001 a epo:Lot;
   epo:hasPurpose epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv;
   epo:isSubjectToLotSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_ACUWmqLfdo5YEi9wsUS9mJ,
     epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_adyhtKZkzxr6SEjy3tRyua;
-  epo:usesTechnique epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_DynamicPurchaseSystemTechnicalUsage_Hu7wzHDygWmeSqTPnwY9wa;
   dct:description "Lot description"@en;
   dct:title "Lot Name"@en;
   adms:identifier epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotIdentifier_adyhtKZkzxr6SEjy3tRyua .

--- a/test_data/sampling_eforms_all_can/eforms-sdk-1.8/op-test-eforms2/2025-OJS002-00001899.xml
+++ b/test_data/sampling_eforms_all_can/eforms-sdk-1.8/op-test-eforms2/2025-OJS002-00001899.xml
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ContractAwardNotice xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<ext:UBLExtensions>
+		<ext:UBLExtension>
+			<ext:ExtensionContent>
+				<efext:EformsExtension>
+					<efac:ContractModification>
+						<efbc:ChangedNoticeIdentifier>801369-2024</efbc:ChangedNoticeIdentifier>
+						<efac:Change>
+							<efbc:ChangeDescription languageID="CES">Doplnění hlukové a rozptylové studie na výhledový stav do roku 2050. Navýšení ceny o 112 000,- Kč bez DPH.</efbc:ChangeDescription>
+							<efac:ChangedSection>
+								<efbc:ChangedSectionIdentifier>CON-0001</efbc:ChangedSectionIdentifier>
+							</efac:ChangedSection>
+						</efac:Change>
+						<efac:ChangeReason>
+							<cbc:ReasonCode listName="modification-justification">add-wss</cbc:ReasonCode>
+							<efbc:ReasonDescription languageID="CES">Doplnění hlukové a rozptylové studie na výhledový stav do roku 2050. Navýšení ceny o 112 000,- Kč bez DPH. </efbc:ReasonDescription>
+						</efac:ChangeReason>
+					</efac:ContractModification>
+					<efac:NoticeResult>
+						<cbc:TotalAmount currencyID="CZK">23624200</cbc:TotalAmount>
+						<efac:LotResult>
+							<cbc:ID schemeName="result">RES-0001</cbc:ID>
+							<efac:AppealRequestsStatistics>
+								<efbc:StatisticsCode listName="review-type">complainants</efbc:StatisticsCode>
+								<efbc:StatisticsNumeric>0</efbc:StatisticsNumeric>
+							</efac:AppealRequestsStatistics>
+							<efac:LotTender>
+								<cbc:ID>TEN-0001</cbc:ID>
+							</efac:LotTender>
+							<efac:SettledContract>
+								<cbc:ID>CON-0001</cbc:ID>
+							</efac:SettledContract>
+							<efac:TenderLot>
+								<cbc:ID>LOT-0001</cbc:ID>
+							</efac:TenderLot>
+						</efac:LotResult>
+						<efac:LotTender>
+							<cbc:ID schemeName="tender">TEN-0001</cbc:ID>
+							<cbc:RankCode>1</cbc:RankCode>
+							<efbc:TenderRankedIndicator>false</efbc:TenderRankedIndicator>
+							<cac:LegalMonetaryTotal>
+								<cbc:PayableAmount currencyID="CZK">23736200</cbc:PayableAmount>
+							</cac:LegalMonetaryTotal>
+							<efac:SubcontractingTerm>
+								<efbc:TermCode listName="applicability">no</efbc:TermCode>
+							</efac:SubcontractingTerm>
+							<efac:TenderingParty>
+								<cbc:ID>TPA-0001</cbc:ID>
+							</efac:TenderingParty>
+							<efac:TenderLot>
+								<cbc:ID>LOT-0001</cbc:ID>
+							</efac:TenderLot>
+							<efac:TenderReference>
+								<cbc:ID>TEN-0001</cbc:ID>
+							</efac:TenderReference>
+						</efac:LotTender>
+						<efac:SettledContract>
+							<cbc:ID schemeName="contract">CON-0001</cbc:ID>
+							<cbc:AwardDate>2021-04-16+02:00</cbc:AwardDate>
+							<cbc:IssueDate>2021-05-26+02:00</cbc:IssueDate>
+							<efac:ContractReference>
+								<cbc:ID>E618-S-2234/2021/PH </cbc:ID>
+							</efac:ContractReference>
+							<efac:LotTender>
+								<cbc:ID>TEN-0001</cbc:ID>
+							</efac:LotTender>
+						</efac:SettledContract>
+						<efac:TenderingParty>
+							<cbc:ID schemeName="tendering-party">TPA-0001</cbc:ID>
+							<efac:Tenderer>
+								<cbc:ID>ORG-0003</cbc:ID>
+								<efbc:GroupLeadIndicator>true</efbc:GroupLeadIndicator>
+							</efac:Tenderer>
+							<efac:Tenderer>
+								<cbc:ID>ORG-0004</cbc:ID>
+								<efbc:GroupLeadIndicator>false</efbc:GroupLeadIndicator>
+							</efac:Tenderer>
+						</efac:TenderingParty>
+					</efac:NoticeResult>
+					<efac:NoticeSubType>
+						<cbc:SubTypeCode listName="cont-modif">39</cbc:SubTypeCode>
+					</efac:NoticeSubType>
+					<efac:Organizations>
+						<efac:Organization>
+							<efbc:AcquiringCPBIndicator>false</efbc:AcquiringCPBIndicator>
+							<efbc:AwardingCPBIndicator>false</efbc:AwardingCPBIndicator>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID schemeName="organization">ORG-0001</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="CES">Správa železnic, státní organizace</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>Dlážděná 1003</cbc:StreetName>
+									<cbc:CityName>Praha</cbc:CityName>
+									<cbc:PostalZone>11000</cbc:PostalZone>
+									<cac:Country>
+										<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>70994234</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Name>Ing. Martin Kosmál, Stavební správa vysokorychlostních tratí</cbc:Name>
+									<cbc:Telephone>+420 602741737</cbc:Telephone>
+									<cbc:ElectronicMail>kosmal@spravazeleznic.cz</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+						<efac:Organization>
+							<efac:Company>
+								<cbc:WebsiteURI>https://uohs.gov.cz</cbc:WebsiteURI>
+								<cac:PartyIdentification>
+									<cbc:ID schemeName="organization">ORG-0002</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="CES">Úřad pro ochranu hospodářské soutěže</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>třída Kpt. Jaroše 1926/7</cbc:StreetName>
+									<cbc:CityName>Brno</cbc:CityName>
+									<cbc:PostalZone>60200</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts">CZ064</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>65349423</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Telephone>+420 542167111</cbc:Telephone>
+									<cbc:ElectronicMail>posta@uohs.cz</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+						<efac:Organization>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID schemeName="organization">ORG-0003</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="CES">METROPROJEKT Praha a.s.</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>Argentinská 1621/36</cbc:StreetName>
+									<cbc:CityName>Praha - Holešovice</cbc:CityName>
+									<cbc:PostalZone>17000</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts">CZ010</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>45271895</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Telephone>+420 296154105</cbc:Telephone>
+									<cbc:ElectronicMail>vladimir.seidl@metroprojekt.cz</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+						<efac:Organization>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID schemeName="organization">ORG-0004</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="CES">ov architekti, s.r.o.</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>Lotyšská 646/10</cbc:StreetName>
+									<cbc:CityName>Praha - Bubeneč</cbc:CityName>
+									<cbc:PostalZone>16000</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts">CZ010</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>24758094</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Telephone>+420 724708065</cbc:Telephone>
+									<cbc:ElectronicMail>ova@ova.cz</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+					</efac:Organizations>
+				<efac:Publication><efbc:NoticePublicationID schemeName="ojs-notice-id">00001899-2025</efbc:NoticePublicationID><efbc:GazetteID schemeName="ojs-id">2/2025</efbc:GazetteID><efbc:PublicationDate>2025-01-03+01:00</efbc:PublicationDate></efac:Publication></efext:EformsExtension>
+			</ext:ExtensionContent>
+		</ext:UBLExtension>
+	</ext:UBLExtensions>
+	<cbc:UBLVersionID>2.3</cbc:UBLVersionID>
+	<cbc:CustomizationID>eforms-sdk-1.8</cbc:CustomizationID>
+	<cbc:ID schemeName="notice-id">8b8ede7d-00ba-4a87-870b-e7027fdc4a32</cbc:ID>
+	<cbc:ContractFolderID>6c67d68c-a6b4-40c0-bf9f-41ffa743d6e7</cbc:ContractFolderID>
+	<cbc:IssueDate>2025-01-02+01:00</cbc:IssueDate>
+	<cbc:IssueTime>08:37:59+01:00</cbc:IssueTime>
+	<cbc:VersionID>01</cbc:VersionID>
+	<cbc:RegulatoryDomain>32014L0025</cbc:RegulatoryDomain>
+	<cbc:NoticeTypeCode listName="cont-modif">can-modif</cbc:NoticeTypeCode>
+	<cbc:NoticeLanguageCode listName="language">CES</cbc:NoticeLanguageCode>
+	<cac:ContractingParty>
+		<cac:Party>
+			<cac:PartyIdentification>
+				<cbc:ID>ORG-0001</cbc:ID>
+			</cac:PartyIdentification>
+		</cac:Party>
+	</cac:ContractingParty>
+	<cac:TenderingTerms>
+		<cac:ProcurementLegislationDocumentReference>
+			<cbc:ID>32014L0025</cbc:ID>
+			<cbc:DocumentDescription languageID="CES">Směrnice Evropského parlamentu a Rady 2014/25/EU ze dne 26. února 2014 o zadávání zakázek subjekty působícími v odvětví vodního hospodářství, energetiky, dopravy a poštovních služeb a o zrušení směrnice 2004/17/ES</cbc:DocumentDescription>
+		</cac:ProcurementLegislationDocumentReference>
+		<cac:ProcurementLegislationDocumentReference>
+			<cbc:ID>134/2016 Sb.</cbc:ID>
+			<cbc:DocumentDescription languageID="CES">Zákon o zadávání veřejných zakázek</cbc:DocumentDescription>
+		</cac:ProcurementLegislationDocumentReference>
+	</cac:TenderingTerms>
+	<cac:ProcurementProject>
+		<cbc:ID>21368/2021-SŽ-GŘ-O21</cbc:ID>
+		<cbc:Name languageID="CES">DÍLČÍ PROJEKTOVÉ A KONZULTAČNÍ PRÁCE NA PROJEKTU TERMINÁL PRAHA VÝCHOD - Dodatek 5 k SOD, část 1/2
+</cbc:Name>
+		<cbc:Description languageID="CES">Jedná se o jednací řízení bez uveřejnění navazující na soutěž o návrh s názvem „TERMINÁL PRAHA VÝCHOD“, jejíž oznámení bylo dne 4. 9. 2020 uveřejněno ve Věstníku veřejných zakázek pod evidenčním číslem Z2020-031279 a v Úředním věstníku Evropské Unie pod evidenčním číslem 2020/S 175-423793, k účasti v JŘBU navazujícím na soutěž o návrh. 
+
+Účelem JŘBU navazujícího na soutěž o návrh je bližší konkretizace podmínek, za nichž bude veřejná zakázka, jejímž předmětem je výběr dodavatele projekčních a konzultačních prací na projektu TERMINÁL PRAHA VÝCHOD, zadána.</cbc:Description>
+		<cbc:ProcurementTypeCode listName="contract-nature">services</cbc:ProcurementTypeCode>
+		<cac:MainCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">71000000</cbc:ItemClassificationCode>
+		</cac:MainCommodityClassification>
+		<cac:AdditionalCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">71200000</cbc:ItemClassificationCode>
+		</cac:AdditionalCommodityClassification>
+		<cac:AdditionalCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">71320000</cbc:ItemClassificationCode>
+		</cac:AdditionalCommodityClassification>
+		<cac:AdditionalCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">71221000</cbc:ItemClassificationCode>
+		</cac:AdditionalCommodityClassification>
+		<cac:AdditionalCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">71242000</cbc:ItemClassificationCode>
+		</cac:AdditionalCommodityClassification>
+		<cac:RealizedLocation>
+			<cac:Address>
+				<cbc:CountrySubentityCode listName="nuts">CZ010</cbc:CountrySubentityCode>
+				<cac:Country>
+					<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:RealizedLocation>
+	</cac:ProcurementProject>
+	<cac:ProcurementProjectLot>
+		<cbc:ID schemeName="Lot">LOT-0001</cbc:ID>
+		<cac:TenderingTerms>
+			<cac:AdditionalInformationParty>
+				<cac:PartyIdentification>
+					<cbc:ID>ORG-0001</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:AdditionalInformationParty>
+			<cac:DocumentProviderParty>
+				<cac:PartyIdentification>
+					<cbc:ID>ORG-0001</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:DocumentProviderParty>
+			<cac:AppealTerms>
+				<cac:PresentationPeriod>
+					<cbc:Description languageID="CES">Podmínkou pro podání návrhu k ÚOHS je podání námitek k Zadavateli, které je nutné doručit do 15 dnů ode dne, kdy se stěžovatel dozvěděl o domnělém porušení zákona Zadavatelem, nejpozději však do uzavření smlouvy nebo do chvíle, kdy se soutěž o návrh považuje po výběru návrhu za ukončenou.
+
+Námitky proti úkonům oznamovaným v dokumentech, které je Zadavatel povinen podle zákona uveřejnit či odeslat stěžovateli, musí být doručeny Zadavateli do 15 dnů od jejich uveřejnění či doručení stěžovateli.
+Pokud je v zadávacím řízení stanovena lhůta pro podání žádostí o účast, musí být námitky proti podmínkám vztahujícím se ke kvalifikaci dodavatele doručeny Zadavateli nejpozději do skončení této lhůty.
+Pokud je v zadávacím řízení stanovena lhůta pro podání nabídek, musí být námitky proti zadávacím podmínkám doručeny Zadavateli nejpozději do skončení této lhůty. Námitky proti obsahu výzvy k podání nabídek v dynamickém nákupním systému nebo při zadávání veřejné zakázky na základě rámcové dohody musí být zadavateli doručeny nejpozději do konce lhůty pro podání nabídek. V soutěži o návrh musí být námitky proti soutěžním podmínkám doručeny nejpozději do konce lhůty pro podání návrhů. Zadavatel může v zadávací dokumentaci nebo soutěžních podmínkách stanovit, že námitky podle § 242 odst. 3 nebo 4 zákona lze podat nejpozději 72 hodin před skončením lhůt podle § 242 odst. 3 nebo 4 zákona.
+
+Námitky proti dobrovolnému oznámení o záměru uzavřít smlouvu podle § 212 odst. 2 zákona musí být doručeny Zadavateli do 30 dnů od uveřejnění tohoto oznámení.
+
+Zadavatel je povinen námitky vyřídit do 15 dnů. Návrh je nutné doručit ÚOHS i Zadavateli do 10 dnů ode dne, v němž stěžovatel obdržel rozhodnutí, kterým Zadavatel námitky odmítnul nebo do 25 dnů od odeslání námitek, pokud Zadavatel o námitkách nerozhodl.
+
+Po uzavření smlouvy na veřejnou zakázku či rámcové dohody lze podat pouze návrh na uložení zákazu plnění smlouvy, a to i bez předchozího podání námitek. Návrh na uložení zákazu plnění smlouvy doručí navrhovatel ÚOHS a ve stejnopisu Zadavateli do 30 dnů ode dne, kdy Zadavatel uveřejnil oznámení o uzavření smlouvy způsobem podle § 212 odst. 2 zákona s uvedením důvodu pro zadání veřejné zakázky bez uveřejnění oznámení o zahájení zadávacího řízení, předběžného oznámení nebo výzvy k podání nabídek ve zjednodušeném podlimitním řízení, nejpozději však do 6 měsíců od uzavření této smlouvy. Návrh na uložení zákazu plnění smlouvy podle § 254 odstavce 1 písm. d) zákona doručí navrhovatel ÚOHS a ve stejnopisu Zadavateli do 30 dnů ode dne, kdy Zadavatel uveřejnil oznámení o uzavření smlouvy na základě rámcové dohody podle § 137 zákona nebo oznámení o uzavření smlouvy v dynamickém nákupním systému podle § 142 zákona, nejpozději však do 6 měsíců od uzavření této smlouvy.
+
+Ve lhůtě pro doručení návrhu je navrhovatel povinen složit na účet ÚOHS kauci ve výši 1 % z nabídkové ceny navrhovatele za celou dobu plnění veřejné zakázky nebo za dobu prvních čtyř let plnění v případě smluv na dobu neurčitou, nejméně však ve výši 50 000 Kč, nejvýše ve výši 10 000 000 Kč. V případě, že navrhovatel nemůže stanovit celkovou nabídkovou cenu, je povinen složit kauci ve výši 100 000 Kč. V případě návrhu na uložení zákazu plnění smlouvy je navrhovatel povinen složit kauci ve výši 200 000 Kč. Jde-li o řízení o přezkoumání postupu pro zadávání koncesí, je navrhovatel povinen ve lhůtě pro doručení návrhu složit na účet ÚOHS kauci ve výši 1 % z předpokládané hodnoty koncese uveřejněné ve Věstníku veřejných zakázek nebo na profilu Zadavatele, nejméně však ve výši 50 000 Kč, nejvýše ve výši 10 000 000 Kč. V případě, že Zadavatel neuveřejní ve Věstníku veřejných zakázek nebo na profilu Zadavatele předpokládanou hodnotu koncese, je navrhovatel povinen složit kauci ve výši 100 000 Kč. V případě návrhu na uložení zákazu plnění koncesní smlouvy je navrhovatel povinen složit kauci ve výši 200 000 Kč.</cbc:Description>
+				</cac:PresentationPeriod>
+				<cac:AppealInformationParty>
+					<cac:PartyIdentification>
+						<cbc:ID>ORG-0002</cbc:ID>
+					</cac:PartyIdentification>
+				</cac:AppealInformationParty>
+				<cac:AppealReceiverParty>
+					<cac:PartyIdentification>
+						<cbc:ID>ORG-0002</cbc:ID>
+					</cac:PartyIdentification>
+				</cac:AppealReceiverParty>
+			</cac:AppealTerms>
+		</cac:TenderingTerms>
+		<cac:TenderingProcess>
+			<cbc:GovernmentAgreementConstraintIndicator>true</cbc:GovernmentAgreementConstraintIndicator>
+		</cac:TenderingProcess>
+		<cac:ProcurementProject>
+			<cbc:ID>21368/2021-SŽ-GŘ-O21</cbc:ID>
+			<cbc:Name languageID="CES">DÍLČÍ PROJEKTOVÉ A KONZULTAČNÍ PRÁCE NA PROJEKTU TERMINÁL PRAHA VÝCHOD - Dodatek 5 k SOD, část 1/2
+</cbc:Name>
+			<cbc:Description languageID="CES">Jedná se o jednací řízení bez uveřejnění navazující na soutěž o návrh s názvem „TERMINÁL PRAHA VÝCHOD“, jejíž oznámení bylo dne 4. 9. 2020 uveřejněno ve Věstníku veřejných zakázek pod evidenčním číslem Z2020-031279 a v Úředním věstníku Evropské Unie pod evidenčním číslem 2020/S 175-423793, k účasti v JŘBU navazujícím na soutěž o návrh. 
+
+Účelem JŘBU navazujícího na soutěž o návrh je bližší konkretizace podmínek, za nichž bude veřejná zakázka, jejímž předmětem je výběr dodavatele projekčních a konzultačních prací na projektu TERMINÁL PRAHA VÝCHOD, zadána.</cbc:Description>
+			<cbc:ProcurementTypeCode listName="contract-nature">services</cbc:ProcurementTypeCode>
+			<cbc:Note languageID="CES">V poli "Hodnota všech veřejných zakázek uvedených v oznámení (BT-161-NoticeResult)" je započtena také hodnota změn provedených v rámci Dodatku 1 a Dodatku 4 k SOD. Změny dle Dodatku 1 a Dodatku 4 byly oznámeny formuláři F20 (Dodatek 1 - evidenční číslo formuláře F2023-056333, Dodatek 4 - evidenční číslo formuláře F2023-056339), které byly chybně navázány na formulář F13 soutěže o návrh s názvem TERMINÁL PRAHA VÝCHOD, kterým byl oznámen výsledek soutěže o návrh (evidenční číslo formuláře F2021-005263). Uvedené změny měly být správně navázány na formulář o výsledku následného JŘBÚ s názvem "DÍLČÍ PROJEKTOVÉ A KONZULTAČNÍ PRÁCE NA PROJEKTU TERMINÁL PRAHA VÝCHOD". Zadavatel tímto provádí opravu výše uvedených informací.
+</cbc:Note>
+			<cac:ProcurementAdditionalType>
+				<cbc:ProcurementTypeCode listName="strategic-procurement">none</cbc:ProcurementTypeCode>
+				<cbc:ProcurementType languageID="CES">V době zadání nebylo odpovědné zadávaní aplikováno.</cbc:ProcurementType>
+			</cac:ProcurementAdditionalType>
+			<cac:MainCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">71000000</cbc:ItemClassificationCode>
+			</cac:MainCommodityClassification>
+			<cac:AdditionalCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">71320000</cbc:ItemClassificationCode>
+			</cac:AdditionalCommodityClassification>
+			<cac:AdditionalCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">71242000</cbc:ItemClassificationCode>
+			</cac:AdditionalCommodityClassification>
+			<cac:AdditionalCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">71221000</cbc:ItemClassificationCode>
+			</cac:AdditionalCommodityClassification>
+			<cac:AdditionalCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">71200000</cbc:ItemClassificationCode>
+			</cac:AdditionalCommodityClassification>
+			<cac:RealizedLocation>
+				<cac:Address>
+					<cbc:CountrySubentityCode listName="nuts">CZ010</cbc:CountrySubentityCode>
+					<cac:Country>
+						<cbc:IdentificationCode listName="country">CZE</cbc:IdentificationCode>
+					</cac:Country>
+				</cac:Address>
+			</cac:RealizedLocation>
+			<cac:PlannedPeriod>
+				<cbc:StartDate>2021-05-26+02:00</cbc:StartDate>
+				<cbc:EndDate>2022-02-18+01:00</cbc:EndDate>
+			</cac:PlannedPeriod>
+		</cac:ProcurementProject>
+	</cac:ProcurementProjectLot>
+	<cac:TenderResult>
+		<cbc:AwardDate>2000-01-01Z</cbc:AwardDate>
+	</cac:TenderResult>
+</ContractAwardNotice>


### PR DESCRIPTION
In some notices the DPS is forbidden. Adding a guard solves this problem for not only those notice subtypes, but all of them, where the ContractingSystemTypeCode and its parent are absent. This can be seen in the PMC reference example test file. In addition, we include for testing a sample notice where this is forbidden, 2025-OJS002-00001899 (1899-2025).

Fixes TEDSWS-303.