### PR TITLE
Fix empty SelectionCriterion Constraint for SDK v1.3-1.7

### DIFF
--- a/mappings/package_eforms_sdk1.3_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.3_epo4.0/metadata.json
@@ -66,5 +66,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "fc88ace3a388880512a6d93deedaa90ceeb562ddc041535d7e1e02f82602236f"
+    "mapping_suite_hash_digest": "3ff2141741e6dc54814d77798b8743420dbff453a18cb1df11a464d14d3ac92f"
 }

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.5_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.5_epo4.0/metadata.json
@@ -66,5 +66,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "ddd734acc2a9fc3e9bf8af18164efa0993b431336b6ce092b7a12cede31b08e5"
+    "mapping_suite_hash_digest": "c09990f2a0da29c39526c62bb851879ec139d2a6d40580d20fed26ed4c430add"
 }

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.6_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.6_epo4.0/metadata.json
@@ -66,5 +66,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "441dec3e52f14ffee58610f23425b56f77097d1d97bda8ad702ef96f459b205c"
+    "mapping_suite_hash_digest": "bb3ef3b6d57208b6f84474a62ba55824485ce49ec5fe650526171469dd8e4917"
 }

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.7_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.7_epo4.0/metadata.json
@@ -66,5 +66,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "bade04f833b452fe031438c64bb59249367a92ab62e2145ced23fb34c5d9407c"
+    "mapping_suite_hash_digest": "3b52ad838939909266d83c808fddfb6d99c1d8c4240c06b0c714d627225af311"
 }

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.8_epo4.0/metadata.json
+++ b/mappings/package_eforms_sdk1.8_epo4.0/metadata.json
@@ -66,5 +66,5 @@
             ]
         }
     },
-    "mapping_suite_hash_digest": "47e67e854b3c6f18a0aed684c900039855d46c6e83bd1eae2b1063c762a8eae0"
+    "mapping_suite_hash_digest": "dfa9d824102c5399f1f51b0d455c22eb5604f61315fa4f6fd17dcdbe907c0e90"
 }

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap

--- a/src/mappings-versioned/Lot_v1.3-1.8.rml.ttl
+++ b/src/mappings-versioned/Lot_v1.3-1.8.rml.ttl
@@ -160,7 +160,7 @@ tedm:MG-Constraint-hasConstraint-SelectionCriterion-specifiesProcurementCriterio
     rr:subjectMap
         [
             rdfs:label "ND-SecondStageThresholdCriterionParameter";
-            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')" ;
+            rml:reference "if (exists(efbc:ParameterCode[@listName='number-threshold'])) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Constraint_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class cccev:Constraint
         ] ;
     rr:predicateObjectMap


### PR DESCRIPTION
While the conditional expressions for the SelectionCriterion weight and threshold were fixed, the v1.3-1.7 mapping for the Constraint (where the threshold value is asserted) was left without a guard. Adding this guard prevents runt instances of the Constraint in notices such as 549867-2024 where there is no threshold.