### PR TITLE
Select reversals of previously retracted bug fixes

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/src/mappings-can/LotAwardOutcome-can.rml.ttl
+++ b/src/mappings-can/LotAwardOutcome-can.rml.ttl
@@ -247,7 +247,7 @@ tedm:MG-LotAwardOutcome_ND-LotResultTenderReference  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
+tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult a rr:TriplesMap ;
     rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
@@ -267,7 +267,7 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
             rr:predicate rdfs:seeAlso ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult ;
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(.)"
@@ -276,19 +276,32 @@ tedm:MG-LotAwardOutcome_ND-StrategicProcurementLotResult  a rr:TriplesMap ;
         ] ;
 .
 
-tedm:MG-VehicleInformation-seeAlso-LotAwardOutcome_ND-StrategicProcurementInformationLotResult  a rr:TriplesMap ;
-    rdfs:label "MG-VehicleInformation";
+tedm:MG-LotAwardOutcome_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
+    rdfs:label "MG-LotAwardOutcome";
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation" ;
+            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails" ;
             rml:referenceFormulation ql:XPath
         ] ;
     rr:subjectMap
         [
-            rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:VehicleInformation
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotAwardOutcome_{../../../cbc:ID}" ;
+            rr:class epo:LotAwardOutcome
+        ] ;
+     rr:predicateObjectMap
+        [
+            rdfs:label "ND-ProcurementDetailsLotResult" ;
+            rr:predicate rdfs:seeAlso ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)"
+                    ];
+                ] ;
         ] ;
 .
 

--- a/src/mappings-can/LotGroupAwardInformation-can.rml.ttl
+++ b/src/mappings-can/LotGroupAwardInformation-can.rml.ttl
@@ -49,22 +49,21 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
                     rr:datatype xsd:decimal ;
                 ] ;
         ] ;
-      rr:predicateObjectMap
-        [
-            rr:predicate epo:hasCurrency ;
-            rr:objectMap
-                [
-                    rml:reference "cbc:EstimatedOverallContractAmount/@currencyID";
-                ] ;
-        ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-156-NoticeResult";
+            rdfs:comment "Currency of Group Framework Maximum Value of MG-MonetaryValue under ND-NoticeResultGroupFA";
             rr:predicate epo:hasCurrency ;
             rr:objectMap
                 [
-                    rml:reference "efbc:GroupFrameworkMaximumValueAmount/@currencyID";
+                    rdfs:label "at-voc:currency" ;
+                    rr:parentTriplesMap tedm:currency ;
+                    rr:joinCondition [
+                        rr:child "efbc:GroupFrameworkMaximumValueAmount/@currencyID" ;
+                        rr:parent "code.value" ;
+                    ] ;
                 ] ;
-        ]
+        ] ;
 .
 
 tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;

--- a/src/mappings-can/LotGroupAwardInformation-can.rml.ttl
+++ b/src/mappings-can/LotGroupAwardInformation-can.rml.ttl
@@ -66,7 +66,7 @@ tedm:MG-MonetaryValue-hasGroupFrameworkAgreementMaximumValue-LotGroupAwardInform
         ] ;
 .
 
-tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA  a rr:TriplesMap ;
+tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA a rr:TriplesMap ;
   rdfs:label "MG-LotGroupAwardInformation";
     rml:logicalSource
         [

--- a/src/mappings-can/PaymentExecutor-can.rml.ttl
+++ b/src/mappings-can/PaymentExecutor-can.rml.ttl
@@ -36,7 +36,7 @@ tedm:MG-ContractTerm-isSubjectToContractSpecificTerm-Contract_ND-PayerParty  a r
         [
             rdfs:label "ND-PayerParty" ;
             rdfs:comment "LotResultTechnicalIdentifier of MG-LotAwardOutcome under ND-LotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(../../efac:SettledContract/cbc:ID)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractTerm_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap

--- a/src/mappings-can/Procedure-can.rml.ttl
+++ b/src/mappings-can/Procedure-can.rml.ttl
@@ -132,7 +132,7 @@ tedm:MG-Procedure-refersToPreviousProcedure-DirectAwardTerm-isSubjectToProcedure
     rr:subjectMap
         [
             rdfs:label "ND-DirectAward";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Procedure_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(cbc:Description)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_Procedure_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:Procedure
         ] ;
 

--- a/src/mappings-can/root-can.rml.ttl
+++ b/src/mappings-can/root-can.rml.ttl
@@ -252,7 +252,7 @@ tedm:MG-Notice_ND-NoticeResult a rr:TriplesMap ;
             rr:predicate epo:announcesLotGroupAwardInformation   ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA ;
+                    rr:parentTriplesMap tedm:MG-LotGroupAwardInformation_ND-NoticeResultGroupFA ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(..)";
@@ -442,22 +442,6 @@ tedm:MG-MonetaryValue-hasApproximateFrameworkAgreementValue-NoticeAwardInformati
                         rr:parent "code.value" ;
                     ] ;
                 ] ;
-        ] ;
-.
-
-tedm:MG-LotGroupAwardInformation-announcesLotGroupAwardInformation-ResultNotice_ND-NoticeResultGroupFA  a rr:TriplesMap ;
-  rdfs:label "MG-LotGroupAwardInformation";
-    rml:logicalSource
-        [
-            rml:source "data/source.xml" ;
-            rml:iterator "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework" ;
-            rml:referenceFormulation ql:XPath
-        ] ;
-    rr:subjectMap
-        [
-            rdfs:label "ND-NoticeResult";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
-            rr:class epo:LotGroupAwardInformation
         ] ;
 .
 

--- a/src/mappings-versioned/VehicleInformation-can_v1.3-1.12.rml.ttl
+++ b/src/mappings-versioned/VehicleInformation-can_v1.3-1.12.rml.ttl
@@ -1,4 +1,4 @@
-#--- MG-VehicleInformation version-specific SDK v0-1.12 ---
+#--- MG-VehicleInformation CAN version-specific SDK v0-1.12 ---
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -35,7 +35,7 @@ tedm:MG-VehicleInformation_ND-ProcurementDetailsLotResult a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementDetailsLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../efac:ProcurementDetails[2])) then path() else path(..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -83,7 +83,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
     rr:subjectMap
         [
             rdfs:label "ND-ProcurementStatistics" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../..)) || '?response_type=raw')}" ;
+            rml:reference "'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(if (exists(../../efac:ProcurementDetails[2])) then path(..) else path(../..)) || '?response_type=raw')" ;
             rr:class epo:VehicleInformation
         ] ;
     rr:predicateObjectMap
@@ -93,7 +93,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasTotalVehicles  ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -104,7 +104,7 @@ tedm:MG-VehicleInformation_ND-ProcurementStatistics a rr:TriplesMap ;
             rr:predicate  epo:hasCleanVehicles   ;
             rr:objectMap
                 [
-                    rml:reference "if (efbc:StatisticsCode='vehicles-clean')then efbc:StatisticsNumeric else null";
+                    rml:reference "if (efbc:StatisticsCode='vehicles-clean') then efbc:StatisticsNumeric else null";
                     rr:datatype xsd:integer  ;
                 ] ;
         ];
@@ -133,9 +133,9 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
     rr:subjectMap
         [
             rdfs:label "ND-StrategicProcurementInformationLotResult" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_VehicleInformation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            rml:reference "if (exists(efbc:ProcurementCategoryCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_VehicleInformation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class epo:VehicleInformation
-        ] ;            
+        ] ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-735-LotResult";
@@ -164,5 +164,5 @@ tedm:MG-VehicleInformation_ND-StrategicProcurementInformationLotResult a rr:Trip
                         rr:parent "path(.)";
                     ];
                 ] ;
-        ] ;        
+        ] ;
 .

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -281,7 +281,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
                     rr:parentTriplesMap tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening ;
                     rr:joinCondition [
                         rr:child "path(.)";
-                        rr:parent "path(../../.)";
+                        rr:parent "path(../..)";
                     ];
                 ] ;
         ];
@@ -1807,8 +1807,8 @@ tedm:MG-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpening a rr:Triples
                 [
                     rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace ;
                     rr:joinCondition[
-                        rr:child "path(..)";
-                        rr:parent "path(../..)"
+                        rr:child "path()";
+                        rr:parent "path(..)"
                     ];
                 ] ;
         ]

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -2058,13 +2058,17 @@ tedm:MG-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
     rr:predicateObjectMap
         [
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate adms:identifier ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding;
+                    rr:parentTriplesMap tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
                 ] ;
-        ];
+        ] ;
 .
 
 tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
@@ -2085,7 +2089,7 @@ tedm:MG-Identifier-identifier-Fund-isFundedBy-Lot_ND-Funding a rr:TriplesMap ;
         [
             tedm:minSDKVersion "1.9.1" ;
             rdfs:label "BT-5010-Lot";
-            rdfs:comment "EUFundsFinancingIdentifier of MG-Identifierunder ND-Funding";
+            rdfs:comment "EU Funds Financing Identifier of MG-Identifierunder ND-Funding";
             rr:predicate skos:notation ;
             rr:objectMap
                 [

--- a/src/mappings/Procedure.rml.ttl
+++ b/src/mappings/Procedure.rml.ttl
@@ -1409,7 +1409,7 @@ tedm:MG-langString-hasCrossBorderLaw-ProcedureTerm-isSubjectToProcedureSpecificT
     rr:predicateObjectMap [
         rr:predicate epo-not:hasCrossBorderLaw ;
         rr:objectMap [
-            rml:reference "." ;
+            rml:reference "if(not(exists(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']) and cbc:DocumentDescription/text() = 'unpublished')) then . else null" ;
             rml:languageMap [
                 fnml:functionValue [
                     rr:predicateObjectMap [

--- a/src/output-can.ttl
+++ b/src/output-can.ttl
@@ -513,7 +513,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotAwardOutcome_RES-0001 a epo:LotAw
   epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w>;
   epo:hasFrameworkAgreementMaximumValue epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_FrameworkAgreementMaximumMonetaryValue_buhfT7xy3UtLfxfwv8HbfT;
   rdfs:seeAlso epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ReviewRequestSummary_FmfbzZdeEatT3nzZdqXd3D,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_2jjdLhfpERsDLUxHpKjft9,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSdQ2254 .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotAwardOutcome_RES-0002 a epo:LotAwardOutcome;
@@ -1360,9 +1359,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_UBOAddress_Kgw52KheiSHAoueYo7YFXX a 
   locn:fullAddress "7 rue de la loi, Bruxelles, 10123, BEL";
   locn:postCode "10123";
   locn:postName "Bruxelles" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_2jjdLhfpERsDLUxHpKjft9
-  a epo:VehicleInformation .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSdQ2254
   a epo:VehicleInformation;

--- a/src/output-cn.ttl
+++ b/src/output-cn.ttl
@@ -435,9 +435,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_W3Ca9teYeCrpDDsQknQZ
   dct:description "Exclusion Ground description ---"@en;
   dct:type <http://publications.europa.eu/resource/authority/exclusion-ground/exg-crim-laund> .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an
-  a epo:ExclusionGround .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_enCwmDFQmvgpZFzckd8DDM
   a epo:ExclusionGround;
   dct:description "Exclusion Ground description ---"@en;
@@ -621,7 +618,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_T6cao22CKGLxFQi5xysxYd,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_UWFyf5GhQc2dCemjvTFRDD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_W3Ca9teYeCrpDDsQknQZHv,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_enCwmDFQmvgpZFzckd8DDM,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_jQoZBxjDris9nSuCxJwQaw,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_kUGZUEpNiDkKQoDVZVAYUT,
@@ -671,7 +667,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_T6cao22CKGLxFQi5xysxYd,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_UWFyf5GhQc2dCemjvTFRDD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_W3Ca9teYeCrpDDsQknQZHv,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_ZY3SnQBRXooC6NjbRDS9an,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_enCwmDFQmvgpZFzckd8DDM,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_jQoZBxjDris9nSuCxJwQaw,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ExclusionGround_kUGZUEpNiDkKQoDVZVAYUT,

--- a/src/output-versioned/can_24_maximal-1.13.ttl
+++ b/src/output-versioned/can_24_maximal-1.13.ttl
@@ -513,7 +513,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotAwardOutcome_RES-0001 a epo:LotAw
   epo:hasAwardStatus <http://publications.europa.eu/resource/authority/winner-selection-status/selec-w>;
   epo:hasFrameworkAgreementMaximumValue epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_FrameworkAgreementMaximumMonetaryValue_buhfT7xy3UtLfxfwv8HbfT;
   rdfs:seeAlso epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ReviewRequestSummary_FmfbzZdeEatT3nzZdqXd3D,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_2jjdLhfpERsDLUxHpKjft9,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSdQ2254 .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotAwardOutcome_RES-0002 a epo:LotAwardOutcome;
@@ -1360,9 +1359,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_UBOAddress_Kgw52KheiSHAoueYo7YFXX a 
   locn:fullAddress "7 rue de la loi, Bruxelles, 10123, BEL";
   locn:postCode "10123";
   locn:postName "Bruxelles" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_2jjdLhfpERsDLUxHpKjft9
-  a epo:VehicleInformation .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSdQ2254
   a epo:VehicleInformation;


### PR DESCRIPTION
Fixes for the following 8 issues:

- [TEDSWS-387 Conflated VehicleInformation properties, empty instances](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-387)
- [TEDSWS-388 Missing privacy condition for BT-09(b)-Procedure hasCrossBorderLaw](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-388)
- [TEDSWS-389 Conflated BT-5010-Lot isFundedBy Fund adms:identifier values](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-389)
- [TEDSWS-390 Conflated BT-133-Lot definesOpeningPlace values](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-390)
- [TEDSWS-391 Empty LotGroupAwardInformation in LotGroup announcesLotGroupAwardInformation](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-391)
- [TEDSWS-392 Missing currency for BT-156-NoticeResult in NoticeAwardInformation](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-392)
- [TEDSWS-394 Runt/empty Procedure instance in DirectAwardTerm refersToPreviousProcedure](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-394)
- [TEDSWS-393 Orphan ContractTerm related to ND-PayerParty](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-393)

Outputs are in a separate branch so as to not overload the GitHub Files changed view https://github.com/OP-TED/ted-rdf-mapping-eforms/pull/168