### PR TITLE
Add Notice->LotGroup announces/refersTo relationships

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-dap.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/src/mappings-can/root-can-modif.rml.ttl
+++ b/src/mappings-can/root-can-modif.rml.ttl
@@ -47,26 +47,6 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/src/mappings-can/root-can-modif.rml.ttl
+++ b/src/mappings-can/root-can-modif.rml.ttl
@@ -47,6 +47,26 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ContractModificationNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ContractModificationNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/src/mappings-can/root-can-modif.rml.ttl
+++ b/src/mappings-can/root-can-modif.rml.ttl
@@ -47,6 +47,16 @@ tedm:MG-ContractModificationNotice_ND-Root
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_Notice" ;
             rr:class epo-not:ContractModificationNotice
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ContractModificationNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ContractModificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractModificationNotice_ND-ContractModification a rr:TriplesMap ;

--- a/src/mappings-can/root-can.rml.ttl
+++ b/src/mappings-can/root-can.rml.ttl
@@ -90,26 +90,6 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/src/mappings-can/root-can.rml.ttl
+++ b/src/mappings-can/root-can.rml.ttl
@@ -90,6 +90,16 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/src/mappings-can/root-can.rml.ttl
+++ b/src/mappings-can/root-can.rml.ttl
@@ -90,6 +90,26 @@ tedm:MG-ResultNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-ResultNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-ResultNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-ResultNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-ResultNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 tedm:MG-AgentInRole-announcesRole-Notice_ND-Root_CAN a rr:TriplesMap ;

--- a/src/mappings-can/root-compl.ttl
+++ b/src/mappings-can/root-compl.ttl
@@ -87,6 +87,16 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-LotsGroup" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/src/mappings-can/root-compl.ttl
+++ b/src/mappings-can/root-compl.ttl
@@ -87,6 +87,26 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
+            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
+            rr:predicate epo:concernsLot ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
+            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
+            rr:predicate epo:concernsLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/src/mappings-can/root-compl.ttl
+++ b/src/mappings-can/root-compl.ttl
@@ -87,26 +87,6 @@ tedm:MG-CompletionNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-ReviewRequester_ND-AppealingParty ;
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-Lot-concernsLot-CompletionNotice" ;
-            rdfs:comment "MG-Lot-concernsLot-CompletionNotice under ND-Lot" ;
-            rr:predicate epo:concernsLot ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Lot_ND-Lot
-                ] ;
-        ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-concernsLotGroup-CompletionNotice" ;
-            rdfs:comment "MG-LotGroup-concernsLotGroup-CompletionNotice under ND-LotsGroup" ;
-            rr:predicate epo:concernsLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 .
 
 ##--- Function Parameters ---

--- a/src/mappings-can/root-dap.ttl
+++ b/src/mappings-can/root-dap.ttl
@@ -67,6 +67,16 @@ tedm:MG-DirectAwardPrenotificationNotice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-DirectAwardPrenotificationNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
 .
 
 ##--- Function Parameters ---

--- a/src/mappings/root.rml.ttl
+++ b/src/mappings/root.rml.ttl
@@ -71,6 +71,16 @@ tedm:MG-CompetitionNotice_ND-Root
         ] ;
     rr:predicateObjectMap
         [
+            rdfs:label "MG-LotGroup-announcesLotGroup-CompetitionNotice" ;
+            rdfs:comment "MG-LotGroup-announcesLotGroup-CompetitionNotice under ND-LotsGroup" ;
+            rr:predicate epo:announcesLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-46-Lot" ;
             rdfs:comment "JuryMemberName of MG-CompetitionNotice under ND-AwardingTermsJuryMember" ;
             rr:predicate epo:announcesRole ;
@@ -600,6 +610,16 @@ tedm:MG-Notice_ND-Root
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
+                ] ;
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
+            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
+            rr:predicate epo:refersToLotGroup ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
                 ] ;
         ] ;
 #    rr:predicateObjectMap

--- a/src/mappings/root.rml.ttl
+++ b/src/mappings/root.rml.ttl
@@ -612,16 +612,6 @@ tedm:MG-Notice_ND-Root
                     rr:parentTriplesMap tedm:MG-Lot_ND-Lot
                 ] ;
         ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "MG-LotGroup-refersToLotGroup-Notice" ;
-            rdfs:comment "MG-LotGroup-refersToLotGroup-Notice under ND-Lot" ;
-            rr:predicate epo:refersToLotGroup ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-LotGroup_ND-LotsGroup
-                ] ;
-        ] ;
 #    rr:predicateObjectMap
 #        [
 #            rdfs:comment "Future Notice for MG-ProcessPlanningTerm under ND-Root" ;

--- a/src/output-can-modif.ttl
+++ b/src/output-can-modif.ttl
@@ -178,6 +178,7 @@ epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_MonetaryValueNoticeAwardInformation_
 epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Notice a epo:ContractModificationNotice,
     epo:Notice, epo:Notice38;
   epo:announcesContractAmendment epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractAmendment_QDVw9P5vNjDmtQprjJMs4a;
+  epo:concernsLot epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Lot_LOT-0000;
   epo:hasESenderDispatchDate "2018-08-02T08:08:08+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/cont-modif>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-modif>;

--- a/src/output-can-modif.ttl
+++ b/src/output-can-modif.ttl
@@ -178,7 +178,6 @@ epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_MonetaryValueNoticeAwardInformation_
 epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Notice a epo:ContractModificationNotice,
     epo:Notice, epo:Notice38;
   epo:announcesContractAmendment epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractAmendment_QDVw9P5vNjDmtQprjJMs4a;
-  epo:concernsLot epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Lot_LOT-0000;
   epo:hasESenderDispatchDate "2018-08-02T08:08:08+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/cont-modif>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-modif>;

--- a/src/output-can.ttl
+++ b/src/output-can.ttl
@@ -710,6 +710,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_5coiCKVw5522noPw9K74y9, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_Jo5HCJdPSjbguiDajX3VSL,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_b3hxHE9girtGpZyLAiKU4g, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;
@@ -1371,13 +1373,12 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSd
   epo:specifiesCleanVehicleDirectiveVehicleCategory <http://publications.europa.eu/resource/authority/vehicle-category/n2-n3> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3UgoLWca
-  a epo:VehicleInformation;
   epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
+  a epo:VehicleInformation;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
-    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
-  a epo:PlanningNotice;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
+  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-can.ttl
+++ b/src/output-can.ttl
@@ -710,8 +710,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_5coiCKVw5522noPw9K74y9, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_Jo5HCJdPSjbguiDajX3VSL,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_b3hxHE9girtGpZyLAiKU4g, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;
@@ -1373,12 +1371,13 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSd
   epo:specifiesCleanVehicleDirectiveVehicleCategory <http://publications.europa.eu/resource/authority/vehicle-category/n2-n3> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3UgoLWca
-  epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   a epo:VehicleInformation;
+  epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
-  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
+    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+  a epo:PlanningNotice;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-can.ttl
+++ b/src/output-can.ttl
@@ -716,6 +716,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,
@@ -1374,8 +1375,9 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3Ug
   epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
-  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
+    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+  a epo:PlanningNotice;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-cn.ttl
+++ b/src/output-cn.ttl
@@ -751,7 +751,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-cn.ttl
+++ b/src/output-cn.ttl
@@ -733,6 +733,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -750,6 +751,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-compl.ttl
+++ b/src/output-compl.ttl
@@ -96,7 +96,6 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001 a epo:Lot;
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Notice a epo:CompletionNotice, epo:Notice,
     epo:NoticeE5;
-  epo:concernsLot epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001;
   epo:hasESenderDispatchDate "2025-10-23T00:00:00+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/completion>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/compl>;

--- a/src/output-compl.ttl
+++ b/src/output-compl.ttl
@@ -96,6 +96,7 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001 a epo:Lot;
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Notice a epo:CompletionNotice, epo:Notice,
     epo:NoticeE5;
+  epo:concernsLot epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001;
   epo:hasESenderDispatchDate "2025-10-23T00:00:00+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/completion>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/compl>;

--- a/src/output-versioned/can_24_maximal-1.10.ttl
+++ b/src/output-versioned/can_24_maximal-1.10.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.10.ttl
+++ b/src/output-versioned/can_24_maximal-1.10.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.10.ttl
+++ b/src/output-versioned/can_24_maximal-1.10.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.11.ttl
+++ b/src/output-versioned/can_24_maximal-1.11.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.11.ttl
+++ b/src/output-versioned/can_24_maximal-1.11.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.11.ttl
+++ b/src/output-versioned/can_24_maximal-1.11.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.12.ttl
+++ b/src/output-versioned/can_24_maximal-1.12.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.12.ttl
+++ b/src/output-versioned/can_24_maximal-1.12.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.12.ttl
+++ b/src/output-versioned/can_24_maximal-1.12.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.13.ttl
+++ b/src/output-versioned/can_24_maximal-1.13.ttl
@@ -710,6 +710,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_5coiCKVw5522noPw9K74y9, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_Jo5HCJdPSjbguiDajX3VSL,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_b3hxHE9girtGpZyLAiKU4g, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;
@@ -1371,13 +1373,12 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSd
   epo:specifiesCleanVehicleDirectiveVehicleCategory <http://publications.europa.eu/resource/authority/vehicle-category/n2-n3> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3UgoLWca
-  a epo:VehicleInformation;
   epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
+  a epo:VehicleInformation;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
-    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
-  a epo:PlanningNotice;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
+  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-versioned/can_24_maximal-1.13.ttl
+++ b/src/output-versioned/can_24_maximal-1.13.ttl
@@ -710,8 +710,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_5coiCKVw5522noPw9K74y9, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_Jo5HCJdPSjbguiDajX3VSL,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Reviewer_b3hxHE9girtGpZyLAiKU4g, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;
@@ -1373,12 +1371,13 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_NJqWLgHQbjQCE5pSd
   epo:specifiesCleanVehicleDirectiveVehicleCategory <http://publications.europa.eu/resource/authority/vehicle-category/n2-n3> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3UgoLWca
-  epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   a epo:VehicleInformation;
+  epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
-  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
+    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+  a epo:PlanningNotice;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-versioned/can_24_maximal-1.13.ttl
+++ b/src/output-versioned/can_24_maximal-1.13.ttl
@@ -716,6 +716,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,
@@ -1374,8 +1375,9 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_VehicleInformation_aTxk5f26D5UBUZ3Ug
   epo:concernsGreenProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca;
   epo:specifiesCleanVehicleDirectiveContractType <http://publications.europa.eu/resource/authority/cvd-contract-type/oth-serv-contr> .
 
-epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice a epo:PlanningNotice;
-  epo:announcesPlannedProcurementPart epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice epo:announcesPlannedProcurementPart
+    epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPart_K53mu54F9PCk4RoVqcWwaL;
+  a epo:PlanningNotice;
   adms:identifier epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlanningNoticeIdentifier_K53mu54F9PCk4RoVqcWwaL .
 
 epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_PlannedProcurementPartIdentifier_K53mu54F9PCk4RoVqcWwaL

--- a/src/output-versioned/can_24_maximal-1.3.ttl
+++ b/src/output-versioned/can_24_maximal-1.3.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.3.ttl
+++ b/src/output-versioned/can_24_maximal-1.3.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.3.ttl
+++ b/src/output-versioned/can_24_maximal-1.3.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.4.ttl
+++ b/src/output-versioned/can_24_maximal-1.4.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.4.ttl
+++ b/src/output-versioned/can_24_maximal-1.4.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.4.ttl
+++ b/src/output-versioned/can_24_maximal-1.4.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.5.ttl
+++ b/src/output-versioned/can_24_maximal-1.5.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.5.ttl
+++ b/src/output-versioned/can_24_maximal-1.5.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.5.ttl
+++ b/src/output-versioned/can_24_maximal-1.5.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.6.ttl
+++ b/src/output-versioned/can_24_maximal-1.6.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.6.ttl
+++ b/src/output-versioned/can_24_maximal-1.6.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.6.ttl
+++ b/src/output-versioned/can_24_maximal-1.6.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.7.ttl
+++ b/src/output-versioned/can_24_maximal-1.7.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.7.ttl
+++ b/src/output-versioned/can_24_maximal-1.7.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.7.ttl
+++ b/src/output-versioned/can_24_maximal-1.7.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.8.ttl
+++ b/src/output-versioned/can_24_maximal-1.8.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.8.ttl
+++ b/src/output-versioned/can_24_maximal-1.8.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.8.ttl
+++ b/src/output-versioned/can_24_maximal-1.8.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/can_24_maximal-1.9.ttl
+++ b/src/output-versioned/can_24_maximal-1.9.ttl
@@ -689,8 +689,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
-  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
-  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.9.ttl
+++ b/src/output-versioned/can_24_maximal-1.9.ttl
@@ -689,6 +689,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:announcesNoticeAwardInformation epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_NoticeAwardInformation_JryEpNBTCzNfzKbsxaXwjt;
   epo:announcesRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Subcontractor_iLSVBfZjy4iHRp6Jka4ttD,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Tenderer_TPA-0002;
+  epo:concernsLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:concernsLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:hasESenderDispatchDate "2023-04-23T20:59:32+01:00"^^xsd:dateTime;
   epo:hasFormType <http://publications.europa.eu/resource/authority/form-type/result>;
   epo:hasNoticeType <http://publications.europa.eu/resource/authority/notice-type/can-standard>;

--- a/src/output-versioned/can_24_maximal-1.9.ttl
+++ b/src/output-versioned/can_24_maximal-1.9.ttl
@@ -695,6 +695,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Notice a epo:Notice, epo:Notice29, e
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Procedure_6dcsBnuV4FTNoRpTZHckqN;
   epo:refersToRole epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Buyer_HGvue6GtAm3yppLpDLnBKD,

--- a/src/output-versioned/cn_24_maximal-1.10.ttl
+++ b/src/output-versioned/cn_24_maximal-1.10.ttl
@@ -741,7 +741,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.10.ttl
+++ b/src/output-versioned/cn_24_maximal-1.10.ttl
@@ -723,6 +723,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -740,6 +741,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.11.ttl
+++ b/src/output-versioned/cn_24_maximal-1.11.ttl
@@ -741,7 +741,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.11.ttl
+++ b/src/output-versioned/cn_24_maximal-1.11.ttl
@@ -723,6 +723,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -740,6 +741,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.12.ttl
+++ b/src/output-versioned/cn_24_maximal-1.12.ttl
@@ -741,7 +741,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.12.ttl
+++ b/src/output-versioned/cn_24_maximal-1.12.ttl
@@ -723,6 +723,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -740,6 +741,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.13.ttl
+++ b/src/output-versioned/cn_24_maximal-1.13.ttl
@@ -751,7 +751,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.13.ttl
+++ b/src/output-versioned/cn_24_maximal-1.13.ttl
@@ -733,6 +733,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -750,6 +751,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.3.ttl
+++ b/src/output-versioned/cn_24_maximal-1.3.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.3.ttl
+++ b/src/output-versioned/cn_24_maximal-1.3.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.4.ttl
+++ b/src/output-versioned/cn_24_maximal-1.4.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.4.ttl
+++ b/src/output-versioned/cn_24_maximal-1.4.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.5.ttl
+++ b/src/output-versioned/cn_24_maximal-1.5.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.5.ttl
+++ b/src/output-versioned/cn_24_maximal-1.5.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.6.ttl
+++ b/src/output-versioned/cn_24_maximal-1.6.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.6.ttl
+++ b/src/output-versioned/cn_24_maximal-1.6.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.7.ttl
+++ b/src/output-versioned/cn_24_maximal-1.7.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.7.ttl
+++ b/src/output-versioned/cn_24_maximal-1.7.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.8.ttl
+++ b/src/output-versioned/cn_24_maximal-1.8.ttl
@@ -743,6 +743,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -760,6 +761,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.8.ttl
+++ b/src/output-versioned/cn_24_maximal-1.8.ttl
@@ -761,7 +761,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.9.ttl
+++ b/src/output-versioned/cn_24_maximal-1.9.ttl
@@ -741,7 +741,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
-  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .

--- a/src/output-versioned/cn_24_maximal-1.9.ttl
+++ b/src/output-versioned/cn_24_maximal-1.9.ttl
@@ -723,6 +723,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NonDisclosureAgreementTerm_TT87XZ7rf
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:Notice,
     epo:Notice16;
   epo:announcesLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:announcesLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:announcesProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   epo:announcesRole epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Buyer_HGvue6GtAm3yppLpDLnBKD,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_EmploymentInformationProvider_Lg96o4u3Pe2t4SkoPaxEB3,
@@ -740,6 +741,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Notice a epo:CompetitionNotice, epo:
   epo:hasOfficialLanguage <http://publications.europa.eu/resource/authority/language/ENG>;
   epo:hasVersion "03";
   epo:refersToLot epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002;
+  epo:refersToLotGroup epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotGroup_GLO-0001;
   epo:refersToPrevious epd:id_9c0fd704-64d3-4294-a3b6-6df45911ab9f-01_Notice;
   epo:refersToProcedure epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Procedure_MnX8qyREnFMNLeS5MJAX9K;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_NoticeIdentifier_cMBzh6pL4JRkiaCd4DWjT2 .


### PR DESCRIPTION
Similar to [what has been done for roles](https://github.com/OP-TED/ted-rdf-mapping-eforms/commit/3db3fa8685a45dd9ce2d871a47d3343576aa492b), notices should either announce or refer to the epo:LotGroup depending on the subtype of the notice.

Fixes https://github.com/OP-TED/ted-rdf-mapping-eforms/issues/152, [TEDSWS-400](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-400).