### PR TITLE
Missing BT-01(c)-Procedure legal basis ID if description is absent

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";

--- a/src/mappings/Procedure.rml.ttl
+++ b/src/mappings/Procedure.rml.ttl
@@ -196,6 +196,19 @@ tedm:MG-Procedure_ND-LocalLegalBasisWithID a rr:TriplesMap ;
     #                 rml:reference "cbc:ID";
     #             ] ;
     #     ];
+    # this is a workaround for the ID not being mappable as an ID, and rather repurposed as the description
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-01(c)-Procedure" ;
+            rdfs:comment "Procedure Legal Basis (ID) as Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID " ;
+            rr:predicate epo:hasLegalBasisDescription ;
+            rr:objectMap
+                [
+                    rdfs:label "BT-01(c)-Procedure" ;
+                    rdfs:comment "Language of Procedure Legal Basis (Description) of MG-Procedure under ND-LocalLegalBasisWithID" ;
+                    rml:reference "if(not(exists(cbc:DocumentDescription))) then cbc:ID else null" ;
+                ] ;
+        ] ;
     # rr:predicateObjectMap
     #     [
     #         rdfs:label "BT-01(d)-Procedure";


### PR DESCRIPTION
Map the BT-01(c)-Procedure with a condition on the absence of BT-01(d)-Procedure. Normally these two fields are combined to yield a description, but in the absence of the latter the former would be ignored.

Fixes gh-153, [TEDSWS-396](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-396).