### PR TITLE
Missing AwardCriterion threshold Constraint linkage

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroup.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -454,7 +454,7 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5421 and BT-541";
+            rdfs:label "BT-5421-Lot and BT-541-Lot-WeightNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
@@ -467,11 +467,24 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
+            rdfs:label "BT-5423-Lot and BT-541-Lot-ThresholdNumber";
+            rr:predicate epo:specifiesProcurementCriterion;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(../../../../../../../../..)";
+                    ];
+                ] ;
+        ];
+    rr:predicateObjectMap
+        [
             rdfs:label "BT-5422-Lot and BT-541-Lot-FixedNumber";
             rr:predicate epo:specifiesProcurementCriterion;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -2217,20 +2230,6 @@ tedm:MG-SelectionCriterion-specifiesProcurementCriterion-Lot_ND-SelectionCriteri
                     rr:datatype xsd:boolean;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
-            rr:predicate epo:hasConstraint ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../../../../../../../..)" ;
-                    ];
-                ] ;
-        ]
-
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardCriterion a rr:TriplesMap ;
@@ -2357,6 +2356,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardWeightCriter
                     ] ;
                ] ;
         ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']";
+            rml:referenceFormulation ql:XPath
+        ];
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotAwardThresholdCriterionParameter";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_AwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-Lot,BT-541-Lot-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)";
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ];
 .
 
 tedm:MG-AwardCriterion-specifiesProcurementCriterion-Lot_ND-LotAwardFixedCriterionParameter a rr:TriplesMap ;

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -287,19 +287,6 @@ tedm:MG-Lot_ND-Lot a rr:TriplesMap ;
         ];
     rr:predicateObjectMap
         [
-            rdfs:label "BT-133-Lot";
-            rr:predicate epo:isSubjectToLotSpecificTerm ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../../.)";
-                    ];
-                ] ;
-        ];
-    rr:predicateObjectMap
-        [
             rdfs:label "BT-17-Lot";
             rr:predicate epo:isSubjectToLotSpecificTerm ;
             rr:objectMap

--- a/src/mappings/LotGroup.rml.ttl
+++ b/src/mappings/LotGroup.rml.ttl
@@ -130,7 +130,7 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-5421-LotsGroup-FixedNumber";
-            rr:predicate epo:specifiesProcurementCriterion   ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
                     rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardFixedCriterionParameter ;
@@ -142,11 +142,11 @@ tedm:MG-LotGroup_ND-LotsGroup a rr:TriplesMap ;
         ]   ;
     rr:predicateObjectMap
         [
-            rdfs:label "BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber";
-            rr:predicate epo:hasConstraint ;
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:specifiesProcurementCriterion ;
             rr:objectMap
                 [
-                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter;
+                    rr:parentTriplesMap tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
                     rr:joinCondition [
                         rr:child "path(.)";
                         rr:parent "path(../../../../../../../../..)";
@@ -583,6 +583,35 @@ tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardW
                     rr:joinCondition [
                         rr:child "if(not(exists(efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']) and efbc:ParameterCode/text() = 'unpublished') and exists(efbc:ParameterNumeric)) then efbc:ParameterCode else null" ;
                         rr:parent "code.value" ;
+                    ] ;
+                ] ;
+        ] ;
+.
+
+tedm:MG-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter a rr:TriplesMap ;
+    rdfs:label "MG-AwardCriterion" ;
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']" ;
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label  "ND-LotsGroupAwardThresholdCriterionParameter" ;
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_LotGroupAwardCriterion_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../../../..)) || '?response_type=raw')}" ;
+            rr:class epo:AwardCriterion
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5423-LotsGroup and BT-541-LotsGroup-ThresholdNumber" ;
+            rr:predicate epo:hasConstraint ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Constraint-hasConstraint-AwardCriterion-specifiesProcurementCriterion-LotGroup_ND-LotsGroupAwardThresholdCriterionParameter ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
                     ] ;
                 ] ;
         ] ;


### PR DESCRIPTION
This occurs due to an unwarranted connection to Constraint from SelectionCriterion and missing AwardCriterion TriplesMap for ND-LotAwardThresholdCriterionParameter `number-threshold`. Affects BT-5423-Lot and BT-541-Lot-ThresholdNumber. Issue can be observed in notice 775926-2023 (CN v1.10).

There is also a missing linkage for the ND-LotAwardFixedCriterionParameter number-fixed counterpart, affecting BT-5422-Lot and BT-541-Lot-FixedNumber, due to duplicate connection for the ND-LotAwardWeightCriterionParameter `number-weight` counterpart. This is not evident in the above notice but may be in others.

Fixes gh-154, [TEDSWS-397](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-397).

In addition, there are two more problems that were discovered while making the above fix:

- BT-5423-LotsGroup, BT-541-LotsGroup-ThresholdNumber `epo:hasConstraint` was wrongly linked from the LotGroup
- BT-133-Lot there was a [redundant and incorrect mapping](https://github.com/OP-TED/ted-rdf-mapping-eforms/blob/a5001d6794e9541c1f7a70fb8be954b6f6d0e898/src/mappings/Lot.rml.ttl#L294) for `epo:isSubjectToLotSpecificTerm` to an Address TMap `tedm:MG-Address-definesOpeningPlace-OpeningTerm-isSubjectToLotSpecificTerm-Lot_ND-PublicOpeningPlace` instead of the OpeningTerm (but the [right TMap already exists](https://github.com/OP-TED/ted-rdf-mapping-eforms/blob/a5001d6794e9541c1f7a70fb8be954b6f6d0e898/src/mappings/Lot.rml.ttl#L281)).