### PR TITLE
Wrong definesLotGroup mapping

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;

--- a/src/mappings/Procedure.rml.ttl
+++ b/src/mappings/Procedure.rml.ttl
@@ -447,6 +447,23 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:datatype xsd:integer
                 ] ;
         ] ;
+.
+
+tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition a rr:TriplesMap ;
+    rdfs:label "MG-ProcedureTerm";
+    rml:logicalSource
+        [
+            rml:source "data/source.xml" ;
+            rml:iterator "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup";
+            rml:referenceFormulation ql:XPath
+        ] ;
+    rr:subjectMap
+        [
+            rdfs:label "ND-LotDistribution";
+            rdfs:comment "Primary type declaration of MG-ProcedureTerm under ND-LotDistribution";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ProcedureTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
+            rr:class epo:ProcedureTerm
+        ] ;
     rr:predicateObjectMap
         [
             # VERINFO: across SDK versions only introduction of Scheme attribute and mapping-irrelevant changes
@@ -459,7 +476,7 @@ tedm:MG-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-LotDistribut
                     rr:parentTriplesMap tedm:MG-LotGroup-definesLotGroup-ProcedureTerm-isSubjectToProcedureSpecificTerm-Procedure_ND-GroupComposition ;
                     # this is an example of a joinCondition with a child element that is a descendant
                     rr:joinCondition [
-                        rr:child "cac:LotsGroup/cbc:LotsGroupID";
+                        rr:child "cbc:LotsGroupID";
                         rr:parent "../cbc:LotsGroupID";
                     ];
                 ] ;


### PR DESCRIPTION
The predicate mapping for `epo:definesLotGroup` was at a broad iterator (at ND-LotDistribution cac:LotDistribution instead of ND-GroupComposition cac:LotsGroup), where the mapping would fail if there were to be more than one LotsGroups.

This is due to an upward traversal parent join which fails if there is more than one element (in this case LotsGroup), in notices like 217262-2025. Create a new TriplesMap at the right iterator to mitigate this.

Fixes gh-155, [TEDWS-398](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-398).