### PR TITLE
Possibly wrong mapping for refersToPreviousNotice for notices without ChangeReason

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;

--- a/src/mappings/ChangeInformation.rml.ttl
+++ b/src/mappings/ChangeInformation.rml.ttl
@@ -78,19 +78,6 @@ tedm:MG-ChangeInformation_ND-ChangeReason  a rr:TriplesMap ;
     #                 ] ;
     #             ] ;
     #     ] ;
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-758-notice";
-            rr:predicate epo:refersToPreviousNotice    ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
-                    rr:joinCondition [
-                        rr:child "path(..)";
-                        rr:parent "path(.)";
-                    ];
-                ] ;
-        ]   ;
 .
 
 tedm:MG-ChangeInformation_ND-Change a rr:TriplesMap ;
@@ -214,7 +201,20 @@ tedm:MG-Notice-concernsNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;
                 [
                     rr:parentTriplesMap tedm:MG-Notice_ND-Root ;
                 ] ;
-        ]
+        ] ;
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-758-notice" ;
+            rr:predicate epo:refersToPreviousNotice ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes ;
+                    rr:joinCondition [
+                        rr:child "path(.)" ;
+                        rr:parent "path(.)" ;
+                    ];
+                ] ;
+        ] ;
 .
 
 tedm:MG-Notice-refersToPreviousNotice-ChangeInformation_ND-Changes a rr:TriplesMap ;


### PR DESCRIPTION
The mapping for BT-758-notice has been mistakenly placed under the TMap for ND-ChangeReason, which has a different iterator and context, mainly to express the reason for a change. However, a ChangeInformation notice like 207280-2025 may not necessarily have a ChangeReason, and therefore the only right place where this should be declared is where concernsNotice is -- at ND-Changes.

Fixes gh-156, [TEDSWS-399](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-399).