### PR TITLE
Conflated hasPlaceOfPerformanceAdditionalInformation and specific/broad place mixup

### DIFF
--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.10_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.11_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.12_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.13_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.3_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.5_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.6_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.7_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.8_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
+++ b/mappings/package_eforms_sdk1.9_epo4.0/transformation/mappings/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/src/mappings-pin/PlannedProcurementPart-pin.rml.ttl
+++ b/src/mappings-pin/PlannedProcurementPart-pin.rml.ttl
@@ -808,7 +808,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-ProcurementObject-foreseesProc
         ];
     rr:subjectMap
         [
-            rdfs:label "ND-PartProcurementScope" ;
+            rdfs:label "ND-PartPerformanceAddress" ;
             rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;

--- a/src/mappings/Lot.rml.ttl
+++ b/src/mappings/Lot.rml.ttl
@@ -3059,19 +3059,6 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotProcurementScope a r
                     ] ;
                 ] ;
         ];
-    rr:predicateObjectMap
-        [
-            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot ";
-            rr:predicate epo:definesSpecificPlaceOfPerformance ;
-            rr:objectMap
-                [
-                    rr:parentTriplesMap tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
-                    rr:joinCondition [
-                        rr:child "path(.)";
-                        rr:parent "path(../..)";
-                    ];
-                ] ;
-        ] ;
      rr:predicateObjectMap
         [
             rdfs:label "BT-36-Lot (object)";
@@ -4228,7 +4215,7 @@ tedm:MG-StrategicProcurement-fulfillsStrategicProcurement-Lot-Lot_ND-Accessibili
 .
 
 tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label "MG-Address" ;
+    rdfs:label "MG-Address" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4238,7 +4225,7 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
     rr:subjectMap
         [
             rdfs:comment "ND-LotPerformanceAddress";
-            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
+            rml:reference "if(not(exists(cbc:Region)) and (exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode))) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocationAddress_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class locn:Address
         ] ;
     rr:predicateObjectMap
@@ -4313,8 +4300,8 @@ tedm:MG-Address-address-Location-definesSpecificPlaceOfPerformance-ContractTerm-
         ] ;
 .
 
-tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
- rdfs:label  "MG-Location" ;
+tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a rr:TriplesMap ;
+    rdfs:label  "MG-Location" ;
     rml:logicalSource
         [
             rml:source "data/source.xml" ;
@@ -4324,7 +4311,8 @@ tedm:Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpe
     rr:subjectMap
         [
             rdfs:label  "ND-LotPerformanceAddress" ;
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractLocation_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw')}" ;
+            # we check for the elements of a linked Address as otherwise this Location should not be instantiated either
+            rml:reference "if(exists(cbc:StreetName) or exists(cbc:AdditionalStreetName) or exists(cac:AddressLine/cbc:Line) or exists(cbc:CityName) or exists(cbc:PostalZone) or exists(cac:Country/cbc:IdentificationCode)) then 'http://data.europa.eu/a4g/resource/id_' || replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-') || '_ContractLocation_' || unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path()) || '?response_type=raw') else null" ;
             rr:class dct:Location
         ];
     rr:predicateObjectMap
@@ -4382,7 +4370,7 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
     rr:subjectMap
         [
             rdfs:label "ND-LotPerformanceAddress";
-            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}";
+            rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}";
             rr:class epo:ContractTerm
         ] ;
     rr:predicateObjectMap
@@ -4402,6 +4390,19 @@ tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress a
                     ] ;
                 ] ;
         ];
+    rr:predicateObjectMap
+        [
+            rdfs:label "BT-5101(a)-Lot, BT-5101(b)-Lot, BT-5101(s)-Lot, BT-5131-Lot, BT-5121-Lot, BT-5071-Lot, BT-5141-Lot " ;
+            rr:predicate epo:definesSpecificPlaceOfPerformance ;
+            rr:objectMap
+                [
+                    rr:parentTriplesMap tedm:MG-Location-definesSpecificPlaceOfPerformance-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPerformanceAddress ;
+                    rr:joinCondition [
+                        rr:child "path()" ;
+                        rr:parent "path()" ;
+                    ] ;
+                ] ;
+        ] ;
 .
 
 tedm:MG-ContractTerm-foreseesContractSpecificTerm-Lot_ND-LotPlacePerformance a rr:TriplesMap ;
@@ -5393,7 +5394,7 @@ tedm:MG-langString-hasPlaceOfPerformanceAdditionalInformation-ContractTerm-fores
   rr:subjectMap [
     rr:class epo-not:ContractTerm ;
     rdfs:label "ND-LotProcurementScope" ;
-    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(../../..)) || '?response_type=raw')}" ;
+    rr:template "http://data.europa.eu/a4g/resource/id_{replace(replace(/*/cbc:ID[@schemeName='notice-id'], ' ', '-' ), '/' , '-')}_ContractTerm_{unparsed-text('https://digest-api.ted-data.eu/api/v1/hashing/fn/uuid/' || encode-for-uri(path(..)) || '?response_type=raw')}" ;
   ] ;
   rr:predicateObjectMap [
     rr:predicate epo-not:hasPlaceOfPerformanceAdditionalInformation ;

--- a/src/output-can-modif.ttl
+++ b/src/output-can-modif.ttl
@@ -119,9 +119,12 @@ epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractModificationInformation_QDVw
   epo:hasModificationJustification <http://publications.europa.eu/resource/authority/modification-justification/add-wss>;
   epo:hasModificationReasonDescription "The original business case was scoped as a technology replacement programme for a single system. Analysis in the early stages of the programme indicated that two core enterprise systems should be replaced. In order to maximise benefit for these systems replacement activities, it was agreed that the organisation should consider people and process in addition to systems replacement, and work has been re-scoped to accommodate this."@en .
 
+epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractTerm_P24wvVmaGggz3wQLy5GuUS a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB .
+
 epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractTerm_jucn4erQJnXcty2wPoNNzB a
     epo:ContractTerm;
-  epo:definesSpecificPlaceOfPerformance epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
 epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Identifier_ORG-0001 a adms:Identifier;
@@ -158,7 +161,8 @@ epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a 
   epo:hasMainClassification <http://data.europa.eu/cpv/cpv/79410000> .
 
 epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_Lot_LOT-0000 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+  epo:foreseesContractSpecificTerm epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractTerm_P24wvVmaGggz3wQLy5GuUS,
+    epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ContractTerm_jucn4erQJnXcty2wPoNNzB;
   epo:hasInternalIdentifier epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_LotInternalIdentifier_4mnqZ7PF3sxbwYtmUHUyS6;
   epo:hasPurpose epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
   epo:isSubjectToLotSpecificTerm epd:id_3572a106-eb30-4c7a-8ac5-b3502f71742a_ReviewTerm_QmkiZENjGqABvzebdMdK43;

--- a/src/output-can.ttl
+++ b/src/output-can.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, 1234, LUX";
   locn:postCode "1234";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -584,7 +588,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_J5SLtyc3vQsib3djj3dAYQ,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Z5WDQyvYPVy4ZuMUnDAGAP,
@@ -610,7 +615,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_eqLHHhCFwNMkmLzkdBL9su,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,

--- a/src/output-cn.ttl
+++ b/src/output-cn.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "1234";
   locn:postName "Luxembourg" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -585,7 +589,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_6gHfSxSpgNRXavjTJCiAJv,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
@@ -634,7 +639,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_o9wtSTkAtb8WTVktoHQWHz,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,

--- a/src/output-compl.ttl
+++ b/src/output-compl.ttl
@@ -35,9 +35,6 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_CompanyAddress_QLSEm2DyTzM8ssuHGXE6H
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU> .
 
-epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
-  a dct:Location .
-
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLotCompletionInformation_h9PW7XzqqD2GZdFvu2JuyF
   a epo:ContractLotCompletionInformation;
   epo:describesLotCompletion epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001;
@@ -49,10 +46,12 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_4TghaR9Riayv2Hb6XHyc6D 
     epo:ContractTerm;
   epo:hasExceedingDurationJustification "Planned period description"@en .
 
+epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_P24wvVmaGggz3wQLy5GuUS a
+    epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea> .
+
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB a
     epo:ContractTerm;
-  epo:definesSpecificPlaceOfPerformance epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTotalPaymentMonetaryValue_h9PW7XzqqD2GZdFvu2JuyF
@@ -88,7 +87,7 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a 
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001 a epo:Lot;
   epo:foreseesContractSpecificTerm epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_4TghaR9Riayv2Hb6XHyc6D,
-    epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+    epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_P24wvVmaGggz3wQLy5GuUS, epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB;
   epo:hasPurpose epd:id_14de6738-d852-4b8e-b913-d532531f0a22_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
   dct:description "Lot description."@en;
   dct:title "Lot title"@en;

--- a/src/output-pmc.ttl
+++ b/src/output-pmc.ttl
@@ -28,13 +28,12 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_CompanyAddress_PcFLvGUMubmeEHZGZJQoe
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
 
-epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractLocation_hM8neAaQhxtDsQ6JVKqiMJ
-  a dct:Location .
+epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_K9GAVi6mfNzSHMo4CbLvAk a
+    epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua a
     epo:ContractTerm;
-  epo:definesSpecificPlaceOfPerformance epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractLocation_hM8neAaQhxtDsQ6JVKqiMJ;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Identifier_ORG-0001 a adms:Identifier;
@@ -50,7 +49,8 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv a 
   epo:hasMainClassification <http://data.europa.eu/cpv/cpv/72000000> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua;
+  epo:foreseesContractSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_K9GAVi6mfNzSHMo4CbLvAk,
+    epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua;
   epo:hasPurpose epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv;
   epo:isSubjectToLotSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_ACUWmqLfdo5YEi9wsUS9mJ,
     epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_adyhtKZkzxr6SEjy3tRyua;

--- a/src/output-versioned/E1_minimal-1.13.ttl
+++ b/src/output-versioned/E1_minimal-1.13.ttl
@@ -28,13 +28,12 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_CompanyAddress_PcFLvGUMubmeEHZGZJQoe
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX> .
 
-epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractLocation_hM8neAaQhxtDsQ6JVKqiMJ
-  a dct:Location .
+epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_K9GAVi6mfNzSHMo4CbLvAk a
+    epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua a
     epo:ContractTerm;
-  epo:definesSpecificPlaceOfPerformance epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractLocation_hM8neAaQhxtDsQ6JVKqiMJ;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Identifier_ORG-0001 a adms:Identifier;
@@ -50,7 +49,8 @@ epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv a 
   epo:hasMainClassification <http://data.europa.eu/cpv/cpv/72000000> .
 
 epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua;
+  epo:foreseesContractSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_K9GAVi6mfNzSHMo4CbLvAk,
+    epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_ContractTerm_adyhtKZkzxr6SEjy3tRyua;
   epo:hasPurpose epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_LotPurpose_hq9SUTbfgyszaBVWP2RTwv;
   epo:isSubjectToLotSpecificTerm epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_ACUWmqLfdo5YEi9wsUS9mJ,
     epd:id_52fe3748-f475-4381-9dbf-31ebb08889e8_SubmissionTerm_adyhtKZkzxr6SEjy3tRyua;

--- a/src/output-versioned/E5_minimal-1.13.ttl
+++ b/src/output-versioned/E5_minimal-1.13.ttl
@@ -35,9 +35,6 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_CompanyAddress_QLSEm2DyTzM8ssuHGXE6H
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/DEU> .
 
-epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB
-  a dct:Location .
-
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLotCompletionInformation_h9PW7XzqqD2GZdFvu2JuyF
   a epo:ContractLotCompletionInformation;
   epo:describesLotCompletion epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001;
@@ -49,10 +46,12 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_4TghaR9Riayv2Hb6XHyc6D 
     epo:ContractTerm;
   epo:hasExceedingDurationJustification "Planned period description"@en .
 
+epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_P24wvVmaGggz3wQLy5GuUS a
+    epo:ContractTerm;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea> .
+
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB a
     epo:ContractTerm;
-  epo:definesSpecificPlaceOfPerformance epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractLocation_5zVCW3b2MSxAnzMuZRbDZB;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-eea>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services> .
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTotalPaymentMonetaryValue_h9PW7XzqqD2GZdFvu2JuyF
@@ -88,7 +87,7 @@ epd:id_14de6738-d852-4b8e-b913-d532531f0a22_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6 a 
 
 epd:id_14de6738-d852-4b8e-b913-d532531f0a22_Lot_LOT-0001 a epo:Lot;
   epo:foreseesContractSpecificTerm epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_4TghaR9Riayv2Hb6XHyc6D,
-    epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB;
+    epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_P24wvVmaGggz3wQLy5GuUS, epd:id_14de6738-d852-4b8e-b913-d532531f0a22_ContractTerm_jucn4erQJnXcty2wPoNNzB;
   epo:hasPurpose epd:id_14de6738-d852-4b8e-b913-d532531f0a22_LotPurpose_4mnqZ7PF3sxbwYtmUHUyS6;
   dct:description "Lot description."@en;
   dct:title "Lot title"@en;

--- a/src/output-versioned/can_24_maximal-1.10.ttl
+++ b/src/output-versioned/can_24_maximal-1.10.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.11.ttl
+++ b/src/output-versioned/can_24_maximal-1.11.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.12.ttl
+++ b/src/output-versioned/can_24_maximal-1.12.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.13.ttl
+++ b/src/output-versioned/can_24_maximal-1.13.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, 1234, LUX";
   locn:postCode "1234";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -584,7 +588,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_J5SLtyc3vQsib3djj3dAYQ,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Z5WDQyvYPVy4ZuMUnDAGAP,
@@ -610,7 +615,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_eqLHHhCFwNMkmLzkdBL9su,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,

--- a/src/output-versioned/can_24_maximal-1.3.ttl
+++ b/src/output-versioned/can_24_maximal-1.3.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.4.ttl
+++ b/src/output-versioned/can_24_maximal-1.4.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.5.ttl
+++ b/src/output-versioned/can_24_maximal-1.5.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.6.ttl
+++ b/src/output-versioned/can_24_maximal-1.6.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.7.ttl
+++ b/src/output-versioned/can_24_maximal-1.7.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.8.ttl
+++ b/src/output-versioned/can_24_maximal-1.8.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/can_24_maximal-1.9.ttl
+++ b/src/output-versioned/can_24_maximal-1.9.ttl
@@ -302,10 +302,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFund_oXwXYzaLxMkFreJUNf6BBv 
   dct:description "Recovery Fund"@en;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractFundIdentifier_oXwXYzaLxMkFreJUNf6BBv .
 
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8ffyDMgaUUK
   a locn:Address;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -313,10 +309,6 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_UuomzHtPoyL8
   locn:fullAddress "Bruce Wayne House, 2 Gotham Street, London, N1 9FL, GBR";
   locn:postCode "N1 9FL";
   locn:postName "London" .
-
-epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKnZwmoPH5Le3
   a locn:Address;
@@ -328,8 +320,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_a7vRB6mj8wKn
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_5rDboKRaxqo6CZogdiqWet .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_Ts6NbgWz9wKHX3CqwnxxzK
   a dct:Location;
@@ -345,8 +336,7 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMga
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocationAddress_YgvcZracvhSgDJFHFzvRUp .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3
   a dct:Location;
@@ -364,30 +354,44 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJU
   epo:hasBeginning "2023-01-01+01:00"^^xsd:date;
   epo:hasEnd "2023-05-23+01:00"^^xsd:date .
 
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8 a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location of lot 2 is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_6rzNvVzvXk5FCPBPRmrELC;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_5rDboKRaxqo6CZogdiqWet,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_UuomzHtPoyL8ffyDMgaUUK;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description lot 2 ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location of lot 2 is ..."@en;
   epo:hasRenewalDescription "Renewal description lot 2 ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractPeriod_nwFgoD6yNKgPvB9L4PsJUF;
-  epo:definesSpecificPlaceOfPerformance epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_YgvcZracvhSgDJFHFzvRUp,
-    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractLocation_a7vRB6mj8wKnZwmoPH5Le3;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasMaximumNumberOfRenewals 3;
   epo:hasOptionsDescription "Options description ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_DynamicPurchaseSystemTechnicalUsage_JdBkiUatysvbDSqaUnVeDH
@@ -569,7 +573,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotPurpose_myo3vCsSuhWxPVpWujDK9s a 
   epo:hasTotalQuantity epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Quantity_myo3vCsSuhWxPVpWujDK9s .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_D2z7FmiJ2mBVfv6qdpqvnW,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_DGvXVEkuAkYV7LdWwqUMHZ, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_RdpZg7b4gA4ZEQmQB5ZNhK;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_Kc62R6i3CT36VZoaXkktTx,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_aTxk5f26D5UBUZ3UgoLWca,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_EdMnyo3SNjas4zTSQ4TnTw,
@@ -593,7 +598,8 @@ epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_LotIdentifier_RdpZg7b4gA4ZEQmQB5ZNhK .
 
 epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
+  epo:foreseesContractSpecificTerm epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_2obs29mYNH7Dgxb93efFi8,
+    epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_HbgAgGxepNYcQ82SYW5phc, epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_ContractTerm_KorWZrEXpQCBgrGqtjBT6W;
   epo:fulfillsStrategicProcurement epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_GreenProcurement_CrSXFRAVKMkjkVH4Y5vFm7,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_InnovativeProcurement_WkofDRMGPe4b3YVS6QPxHE,
     epd:id_15377ca1-6cf7-4060-90f0-9290128957a3_SocialProcurement_dh4moYmHL6hH6iJfjejoFp,

--- a/src/output-versioned/cn_24_maximal-1.10.ttl
+++ b/src/output-versioned/cn_24_maximal-1.10.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -577,7 +581,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -625,7 +630,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.11.ttl
+++ b/src/output-versioned/cn_24_maximal-1.11.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -577,7 +581,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -625,7 +630,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.12.ttl
+++ b/src/output-versioned/cn_24_maximal-1.12.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -577,7 +581,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -625,7 +630,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.13.ttl
+++ b/src/output-versioned/cn_24_maximal-1.13.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "1234";
   locn:postName "Luxembourg" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/LUX>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -585,7 +589,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_6gHfSxSpgNRXavjTJCiAJv,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
@@ -634,7 +639,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_o9wtSTkAtb8WTVktoHQWHz,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,

--- a/src/output-versioned/cn_24_maximal-1.3.ttl
+++ b/src/output-versioned/cn_24_maximal-1.3.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.4.ttl
+++ b/src/output-versioned/cn_24_maximal-1.4.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.5.ttl
+++ b/src/output-versioned/cn_24_maximal-1.5.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.6.ttl
+++ b/src/output-versioned/cn_24_maximal-1.6.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.7.ttl
+++ b/src/output-versioned/cn_24_maximal-1.7.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.8.ttl
+++ b/src/output-versioned/cn_24_maximal-1.8.ttl
@@ -299,14 +299,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -327,13 +319,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -348,10 +338,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -361,17 +348,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -381,9 +381,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -595,7 +599,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -644,7 +649,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,

--- a/src/output-versioned/cn_24_maximal-1.9.ttl
+++ b/src/output-versioned/cn_24_maximal-1.9.ttl
@@ -281,14 +281,6 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_TfeqsbtZz7bn
   locn:postCode "N1 9FL";
   locn:postName "London" .
 
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
-epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas
-  a locn:Address;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
-
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM
   a dct:Location;
   epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
@@ -309,13 +301,11 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_btiykpkF9yYEWFnDmvR
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_e4BUCegaReE8NKq7sHcoAX .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas
   a dct:Location;
-  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR>;
-  locn:address epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocationAddress_es3GJHPAww7U8q366gSYas .
+  epo:hasCountryCode <http://publications.europa.eu/resource/authority/country/GBR> .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek
   a epo:Period;
@@ -330,10 +320,7 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_SwK8Z4wjBuauCWAoBTPk4Z;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -343,17 +330,30 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_es3GJHPAww7U8q366gSYas;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
+  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
+  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ a
     epo:ContractTerm;
   epo:definesContractPeriod epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractPeriod_JNctcsx6JXdNkzdL4P6dek;
-  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_TfeqsbtZz7bnSaeLJEmaKZ,
-    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_e4BUCegaReE8NKq7sHcoAX;
   epo:hasAdditionalContractNature <http://publications.europa.eu/resource/authority/contract-nature/works>;
-  epo:hasBroadPlaceOfPerformance <http://publications.europa.eu/resource/authority/other-place-service/anyw-cou>;
   epo:hasContractNatureType <http://publications.europa.eu/resource/authority/contract-nature/services>;
   epo:hasEInvoicingPermission <http://publications.europa.eu/resource/authority/permission/required>;
   epo:hasEOrdering true;
@@ -363,9 +363,13 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ 
   epo:hasOptionsDescription "Options description ---"@en;
   epo:hasPaymentArrangement "Terms Financial ---"@en;
   epo:hasPerformanceConditions "Terms Performance ---"@en;
-  epo:hasPlaceOfPerformanceAdditionalInformation "Additional information ---"@en, "The main location is ..."@en;
   epo:hasRenewalDescription "Renewal description ---"@en;
   epo:hasReservedExecution <http://publications.europa.eu/resource/authority/applicability/yes> .
+
+epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB a
+    epo:ContractTerm;
+  epo:definesSpecificPlaceOfPerformance epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractLocation_6pwBpb8FW5caR7TKqg7TvM;
+  epo:hasPlaceOfPerformanceAdditionalInformation "The main location is ..."@en .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_DynamicPurchaseSystemTechnicalUsage_4qCitbxYVRfdbqxnYtJTZF
   a epo:DynamicPurchaseSystemTechnique;
@@ -577,7 +581,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotPurpose_QRFEJSYy7fATJoZShoDC4D a 
   epo:hasTotalQuantity epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Quantity_QRFEJSYy7fATJoZShoDC4D .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_N4fbNQxys3ti3VyDu3NDMM,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_VQprYhGmQN6wWMg9owRwcH, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_daUDPcwCUoxbJRjGb7tKNQ;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_YnBjYVCB47Lh3T4W9D8off,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_cLKYnTLDZb6RpEv6sHGwFG,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_AyeF96vKsfhzrt5AYeKRTv,
@@ -625,7 +630,8 @@ epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0001 a epo:Lot;
   adms:identifier epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_LotIdentifier_daUDPcwCUoxbJRjGb7tKNQ .
 
 epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_Lot_LOT-0002 a epo:Lot;
-  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi;
+  epo:foreseesContractSpecificTerm epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_8y8GPfmPvSRdBcci6WWcSi,
+    epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_GBD3fMnrQ4xtMsH9iSvq9b, epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_ContractTerm_hiAK8DLh3JtZ7KtSTBXFaB;
   epo:fulfillsStrategicProcurement epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_GreenProcurement_dfeMpbQbaBY6WfVozDLEGf,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_InnovativeProcurement_2yjckcDCeZgS5m5tUcZ68p,
     epd:id_14549263-b47b-4e59-96a1-2d0d13e19343_SocialProcurement_GB54RbhU2jfyPCJLbcWmfB,


### PR DESCRIPTION
This affects the eForms fields **BT-727-Lot** and **BT-728-Lot**, where the instantiation of the ContractTerm and in turn the broad and specific places of performance is not optimal, resulting in multiple values being asserted for the properties
`epo:hasPlaceOfPerformanceAdditionalInformation` and `epo:definesSpecificPlaceOfPerformance`.

This was accounted for during the mapping of the counterpart `-Part` fields (for PIN notices), where the correct mappings were created to avoid this issue. See commit fe7e3586be391bfe81ac898b12a2b8112db4ee4d "Fix specific/broad place instantiation, refactor contract terms". However, the issue still persisted in CAN and CN mappings.

A guard is placed against `cbc:Region` to avoid creating an address for a broad place. The subject templates for the place of performance's contract is updated to instantiate at the `cbc:RealizedLocation`. This results in separate but harmonized contracts collecting place-related information together. This in turn avoids multiple values being asserted for the additional information and specific place.

Fixes gh-151, [TEDSWS-395](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDSWS-395).